### PR TITLE
Accessibility updates 2

### DIFF
--- a/app/views/admin/dashboard/_navigation.html.slim
+++ b/app/views/admin/dashboard/_navigation.html.slim
@@ -1,5 +1,5 @@
 .nav-subnav
-  ul
+  ul role="navigation"
     li class="dashboard-live #{'active' if params[:action] == "index"}" role="presentation"
       = link_to "Live data", admin_dashboard_index_path
     li class="dashboard-monthly #{'active' if params[:action] == "totals_by_month"}" role="presentation"

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -13,6 +13,6 @@ table.table.applications-table
         = sort_link f, "Flag", @search, :flag, disabled: @search.query?
       th.sortable width="130"
         = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
-      th &nbsp;
+      th View Application
   tbody
     = render("admin/form_answers/list_components/table_body")

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -3,12 +3,12 @@
   tr
     td.td-title
       - unless obj.company_or_nominee_name.nil?
-        = link_to polymorphic_url([namespace_name, obj], search: params[:search]) do
+        = link_to polymorphic_url([namespace_name, obj], search: params[:search]), aria: { label: "View submitted application, for #{obj.company_or_nominee_name}" } do
           = obj.company_or_nominee_name
       - else
-        = link_to polymorphic_url([namespace_name, obj], search: params[:search]) do
+        = link_to polymorphic_url([namespace_name, obj], search: params[:search]), aria: { label: "View submitted application, company or nominee name not yet specified" }do
           em
-            ' Not found
+            ' Not yet specified
     td = obj.dashboard_status(current_admin.class.name)
     td = obj.sic_code
     td = obj.applied_before ? "Yes" : ""

--- a/app/views/admin/form_answers/show.html.slim
+++ b/app/views/admin/form_answers/show.html.slim
@@ -10,7 +10,7 @@
         .clear
 .row.inline-form-view
   .show-sidebar-container
-    .show-sidebar
+    aside.show-sidebar aria-label="Application summary"
       = render("applicant_details")
       = render("applicant_status")
       = render("section_documents")

--- a/app/views/admin/users/_debounce_api_check_details.html.slim
+++ b/app/views/admin/users/_debounce_api_check_details.html.slim
@@ -8,7 +8,7 @@
   - if user_record.debounce_api_latest_check_at.present?
 
     - if user_record.marked_at_bounces_email?
-      = image_tag "icon-important-sm-red.png"
+      = image_tag "icon-important-sm-red.png", alt: ""
       span.check-result-title
         | Bounces
       br
@@ -19,7 +19,7 @@
         = user_record.decorate.debounce_api_check_cycle_details
 
     - else
-      = image_tag "icon-grade-positive.png"
+      = image_tag "icon-grade-positive.png", alt: ""
       span.check-result-title
         | Valid!
       br
@@ -28,7 +28,7 @@
         = user_record.decorate.debounce_api_check_cycle_details
 
   - else
-    = image_tag "icon-info.png"
+    = image_tag "icon-info.png", alt: ""
     span.check-result-title
       | Not scanned yet!
     br

--- a/app/views/admin/users/_navigation.html.slim
+++ b/app/views/admin/users/_navigation.html.slim
@@ -1,5 +1,5 @@
 .nav-subnav
-  ul
+  ul role="navigation"
     - %w[users lieutenants assessors admins].each do |role|
       - if policy(role.singularize.to_sym).index?
         - role_name = role == "users" ? "Applicants" : role.titleize

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,4 +1,4 @@
-header.page-header
+.page-header
   h1
     = "Edit #{controller_name == "users" ? "applicant" : controller_name.singularize}"
 

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,4 +1,4 @@
-header.page-header
+.page-header
   h1
     = "New #{controller_name == "users" ? "applicant" : controller_name.singularize}"
 

--- a/app/views/assessor/form_answers/_category_tabs.html.slim
+++ b/app/views/assessor/form_answers/_category_tabs.html.slim
@@ -1,5 +1,5 @@
 - if category_picker.show_award_tabs_for_assessor?
-  .nav-subnav
+  .nav-subnav role="navigation"
     ul
       - category_picker.visible_categories.each do |category|
         li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -5,20 +5,19 @@ tbody
         td = check_box_tag :check, obj.id, false, class: "form-answer-check"
 
       td.td-title
-        = link_to polymorphic_url([namespace_name, obj], search: params.permit[:search]) do
-          - unless obj.company_or_nominee_name.nil?
-            span.ellipsis
-              = obj.company_or_nominee_name
-          - else
-            em
-              ' Not found
-
+      - unless obj.company_or_nominee_name.nil?
+        = link_to polymorphic_url([namespace_name, obj], search: params[:search]), aria: { label: "View submitted application, for #{obj.company_or_nominee_name}" } do
+          = obj.company_or_nominee_name
+      - else
+        = link_to polymorphic_url([namespace_name, obj], search: params[:search]), aria: { label: "View submitted application, company or nominee name not yet specified" }do
+          em
+            ' Not yet specified
       td
-        - if obj.urn.present?
-          = link_to obj.urn, polymorphic_url([namespace_name, obj], search: params.permit[:search])
-        - else
-          span.urn-not-generated Not yet generated
-
+        = link_to obj.urn, polymorphic_url([namespace_name, obj], search: params.permit[:search]), aria: { label: "Open submitted application page, for #{obj.company_or_nominee_name.presence || "company not yet specified"} application #{ obj.urn.presence ||  obj.id}" }
+          - if obj.urn.present?
+            = obj.urn
+          - else
+            span.urn-not-generated Draft id: #{obj.id}
       td = obj.dashboard_status
       td = obj.sic_code
       td = obj.applied_before ? "Yes" : ""

--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -10,7 +10,7 @@
         .clear
 .row.inline-form-view
   .show-sidebar-container
-    .show-sidebar
+    aside.show-sidebar aria-label="Application summary"
       = render("admin/form_answers/applicant_details")
 
       = render("admin/form_answers/applicant_status")

--- a/app/views/qae_form/_textarea_question.html.slim
+++ b/app/views/qae_form/_textarea_question.html.slim
@@ -6,7 +6,7 @@
 
 .if-no-js-hide
   .js-ckeditor-spinner-block
-    = image_tag "textarea_spinner.gif"
+    = image_tag "textarea_spinner.gif", alt: ""
     span
       | Loading Editor ...
 


### PR DESCRIPTION
- Changed role from 'list' to 'navigation'
- Added table heading to final column in admin index
- Removed link from company name in application index table, for admins and assessors. Also now showing 'Not yet specified' if company name is nil rather than 'Not found', and 'Draft id:' if reference is not yet generated instead of 'Not generated'
- Made left panel on application show page an aside element with aria-label 
- Added empty alt='' tags to images that should be skipped by screen readers
- Removed banners on New User pages