### PR TITLE
removes icon from dashboard

### DIFF
--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -24,4 +24,4 @@
       br
       span.muted
         = obj.last_updated_by
-    td = link_to "View", review_admin_form_answer_path(obj), target: "_blank", class: "icon-view"
+    td = link_to "View", review_admin_form_answer_path(obj), target: "_blank"


### PR DESCRIPTION
Removes the view icon from the nomination row to make more accessible.

<img width="1173" alt="Screenshot 2021-07-19 at 14 42 59" src="https://user-images.githubusercontent.com/65811538/126169477-4560a076-c2f1-4f0b-9b2c-c315d94f5d20.png">
