### PR TITLE
Nominator dashboard UI tweaks

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -433,6 +433,10 @@ header.page-header div {
       a {
         font-size: 14px !important;
       }
+
+      .active {
+        color: #1D8FEB !important
+      }
     }
   }
 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,9 @@
+class SessionsController < Devise::SessionsController
+  after_action :remove_notice, only: :create
+
+  private
+
+  def remove_notice
+    flash[:notice] = nil
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -141,4 +141,8 @@ module ApplicationHelper
       str
     ).text.strip
   end
+
+  def current_class?(path)
+    request.path == path ? "active" : ""
+  end
 end

--- a/app/views/content_only/_current_nominations.html.slim
+++ b/app/views/content_only/_current_nominations.html.slim
@@ -12,9 +12,6 @@
             h3
               = award.decorate.company_or_nominee_name || award.id
               br
-              small
-                = award.award_type_full_name
-                '  Award
           td
             p
               - if award.submitted?

--- a/app/views/content_only/_current_nominations.html.slim
+++ b/app/views/content_only/_current_nominations.html.slim
@@ -9,8 +9,8 @@
       - award_applications.each_with_index do |award, index|
         tr
           td
-            h4
-              - app_name = award.decorate.application_name
+            h3
+              = award.decorate.company_or_nominee_name || award.id
               br
               small
                 = award.award_type_full_name

--- a/app/views/content_only/_current_nominations.html.slim
+++ b/app/views/content_only/_current_nominations.html.slim
@@ -10,7 +10,7 @@
         tr
           td
             h3
-              = award.decorate.company_or_nominee_name || award.id
+              = award.decorate.company_or_nominee_name || "Nomination ID: " + award.id.to_s
               br
           td
             p

--- a/app/views/content_only/_dashboard_deadline_banner.html.slim
+++ b/app/views/content_only/_dashboard_deadline_banner.html.slim
@@ -1,0 +1,9 @@
+div.govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+
+  div.govuk-notification-banner__header
+    h2.govuk-notification-banner__title#govuk-notification-banner-title
+      ' Important
+  div.govuk-notification-banner__content
+    p.govuk-notification-banner__heading
+      ' Submission deadline is 
+      = submission_deadline.decorate.formatted_trigger_time

--- a/app/views/content_only/_dashboard_deadline_banner.html.slim
+++ b/app/views/content_only/_dashboard_deadline_banner.html.slim
@@ -1,9 +1,0 @@
-div.govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-
-  div.govuk-notification-banner__header
-    h2.govuk-notification-banner__title#govuk-notification-banner-title
-      ' Important
-  div.govuk-notification-banner__content
-    p.govuk-notification-banner__heading
-      ' Submission deadline is 
-      = submission_deadline.decorate.formatted_trigger_time

--- a/app/views/content_only/_dashboard_past_applications.html.slim
+++ b/app/views/content_only/_dashboard_past_applications.html.slim
@@ -11,12 +11,4 @@
       .article-container.article-container-widest
         article.group role="article"
           .inner
-            - past_awarded_applications = apps.select { |app| app.awarded? }
-
-            - if past_awarded_applications.present?
-              = render "content_only/past_applications/winners", past_awarded_applications: past_awarded_applications, award_year: award_year
-
-            - past_unsuccessful_applications = apps.select { |app| app.unsuccessful_app? }
-
-            - if past_unsuccessful_applications.present?
-              = render "content_only/past_applications/unsuccessful", past_unsuccessful_applications: past_unsuccessful_applications
+            = render "content_only/past_applications/combined", past_applications: apps

--- a/app/views/content_only/_dashboard_past_applications.html.slim
+++ b/app/views/content_only/_dashboard_past_applications.html.slim
@@ -2,8 +2,9 @@
   header.page-header.group
     div
       h1
-        ' Past Nominations
-        = award_year.year
+        ' Past nominations - 
+        => award_year.year 
+        ' award
 
   .dashboard-post-submission
     .article-related-positioning-container

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -6,6 +6,7 @@
           h4
             ' You can nominate more than one group
           = render "current_nominations", award_applications: @user_award_forms
+          br
         - else
             .application-notice.help-notice
               .alert.alert-warning
@@ -15,12 +16,3 @@
 
         - if submission_started? && !submission_ended?
           = render "shared/application_awards_status"
-
-  - if submission_deadline && submission_deadline.trigger_at
-    .related-positioning.related-positioning-no-header
-      .related-container
-        .related#related
-          .highlighted-event
-            p
-              ' Submission deadline
-              em = submission_deadline.decorate.formatted_trigger_time

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -6,8 +6,12 @@
           h4
             ' You can nominate more than one group
           = render "current_nominations", award_applications: @user_award_forms
-
-          br
+        - else
+            .application-notice.help-notice
+              .alert.alert-warning
+                p.text-bold
+                  ' You haven't submitted any nominations.
+                br
 
         - if submission_started? && !submission_ended?
           = render "shared/application_awards_status"

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -3,22 +3,13 @@
     article.group role="article"
       .inner
         - if @user_award_forms.any?
-          h2
-            ' Current Nominations
+          h4
+            ' You can nominate more than one group
           = render "current_nominations", award_applications: @user_award_forms
 
           br
 
         - if submission_started? && !submission_ended?
-          h2 Nominating a group for The Queen's Award for Voluntary Service
-
-          h2 Continue to the nomination form
-          / deadline notice
-          p 
-            ' It is very important that you read the 
-            => link_to "guidance notes", guidance_notes_path
-            | before submitting your nominations.
-
           = render "shared/application_awards_status"
 
   - if submission_deadline && submission_deadline.trigger_at

--- a/app/views/content_only/_steps_progress_bar.html.slim
+++ b/app/views/content_only/_steps_progress_bar.html.slim
@@ -19,7 +19,7 @@
             = step_link_to step.short_title.html_safe, result_form_award_eligibility_url(form_id: @form_answer.id, anchor: step.title.html_safe.parameterize), index: index + 3, active: 2, index_name: "#{step_letters[index]}.", cant_access_future: false
     li.divider
     li.sidebar-helpline
-      ' Need help? Ring us on
+      ' Need help? Call us on
       br
       ' 0207 271 6206
       span.helpline-space

--- a/app/views/content_only/_submitted_applications.html.slim
+++ b/app/views/content_only/_submitted_applications.html.slim
@@ -1,6 +1,6 @@
 - if award_applications.none?
   .application-notice.help-notice
-    p You did not submit any nominations.
+    p.text-bold You haven't submitted any nominations.
 - else
   - if Settings.winners_stage?
     = render("content_only/post_submission/winners", award_applications: award_applications)

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -2,10 +2,14 @@
 
 - if Settings.after_current_submission_deadline?
   = render "content_only/info_messages/award_season_closed"
-- elsif Settings.current_award_year_switched?
-  = render "content_only/info_messages/award_season_opens_soon"
-- if submission_deadline && submission_deadline.trigger_at
-  = render "dashboard_deadline_banner"
+
+/ hidden for demo purposes
+/ - elsif Settings.current_award_year_switched?
+/   = render "content_only/info_messages/award_season_opens_soon"
+
+
+/ - if submission_deadline && submission_deadline.trigger_at
+/   = render "dashboard_deadline_banner"
 
 - if Settings.after_current_submission_deadline_start? || past_applications.present?
   header.page-header.group

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -9,7 +9,8 @@
   header.page-header.group
     div
       h1
-        ' Nominations
+        => AwardYear.current.year
+        ' award nominations (current)
 
 - if Settings.after_current_submission_deadline?
   .dashboard-post-submission

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -4,6 +4,8 @@
   = render "content_only/info_messages/award_season_closed"
 - elsif Settings.current_award_year_switched?
   = render "content_only/info_messages/award_season_opens_soon"
+- if submission_deadline && submission_deadline.trigger_at
+  = render "dashboard_deadline_banner"
 
 - if Settings.after_current_submission_deadline_start? || past_applications.present?
   header.page-header.group

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -1,11 +1,22 @@
 article.group role="article"
-  header.page-header.group
-    div
-      h2
-        ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May.
-  .inner
-    .application-notice.info-notice
-      p.text-normal
-        ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.
-      p.text-normal
-        ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May. We will email you when it opens.
+  - if !@user_award_forms.any?
+    header.page-header.group
+      div
+        h2
+          ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May.
+    .inner
+      .application-notice.info-notice
+        p.text-normal
+          ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.
+        p.text-normal
+          ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May. We will email you when it opens.
+  - else
+    br
+    .inner
+      .application-notice.info-notice
+        p.text-normal
+          ' The entry period for the #{ AwardYear.current.year } awards has now closed.
+        p.text-normal
+          ' Award winners will be announced on
+          =< application_deadline_for_year(AwardYear.current, :buckingham_palace_attendees_details, "with_year")
+          ' .

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -2,13 +2,7 @@ article.group role="article"
   .inner
     br
     .application-notice.info-notice
-      p
-        = render "content_only/info_messages/new_users_message"
-
-        ' The entry period for the
-        = AwardYear.current.year
-        '  Awards season has now closed.
-        br
-        ' Award winners will be announced on
-        =< application_deadline_for_year(AwardYear.current, :buckingham_palace_attendees_details, "with_year")
-        ' .
+      p.text-normal
+      ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.
+      p.text-normal
+      ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May. We will email you when it opens.

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -1,6 +1,9 @@
 article.group role="article"
+  header.page-header.group
+    div
+      h2
+        ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May.
   .inner
-    br
     .application-notice.info-notice
       p.text-normal
       ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -6,6 +6,6 @@ article.group role="article"
   .inner
     .application-notice.info-notice
       p.text-normal
-      ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.
+        ' Please note, the #{ AwardYear.current.year } award nominations has closed on #{ submission_deadline.decorate.formatted_trigger_time }.
       p.text-normal
-      ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May. We will email you when it opens.
+        ' The new nomination period for the #{ AwardYear.current.year + 1 } awards opens in May. We will email you when it opens.

--- a/app/views/content_only/info_messages/_award_season_opens_soon.html.slim
+++ b/app/views/content_only/info_messages/_award_season_opens_soon.html.slim
@@ -8,8 +8,8 @@ article.group role="article"
         = render "content_only/info_messages/new_users_message"
 
         - if Settings.after_current_submission_deadline_start?
-          ' Please note, we are still in the process of updating the nomination form for the year #{award_year.year}
-          br
+          p.text-normal
+            ' Please note, we are still in the process of updating the nomination form for the year #{award_year.year}
         - else
           ' The entry period for the #{award_year.year - 1} Awards season has now closed.
           br

--- a/app/views/content_only/info_messages/_new_users_message.html.slim
+++ b/app/views/content_only/info_messages/_new_users_message.html.slim
@@ -1,6 +1,4 @@
 - if current_user.new_member?
-  ' Thank you for registering for an account.
-  br
-  ' Please note, the 2021 award nominations closed on the #{ submission_deadline.decorate.formatted_trigger_time }
-  br
-  ' The 2022 award nomination form is currently being updated. Watch out for an email from us - we will notify you as soon as the form becomes available.
+  p.text-normal
+    ' Thank you for registering for an account.
+  

--- a/app/views/content_only/past_applications/_combined.html.slim
+++ b/app/views/content_only/past_applications/_combined.html.slim
@@ -1,0 +1,31 @@
+.container-split
+  
+- past_applications.each do |award|
+  - award = award.decorate
+
+  .container-split.award-list
+    .content-left
+      h3
+        = award.company_or_nominee_name
+        small
+          - if award.awarded?
+            ' Successful
+          - else
+            ' Unsuccessful
+    .content-right.content-offset-24
+      = render "content_only/past_applications/download_pdf_link", award: award
+
+      - if award.not_submitted?
+        p The nomination was not submitted on time.
+      - else
+        h4 Feedback
+        - if award.feedback.try(:submitted?)
+          p
+            ' Please
+            = link_to "download and read the feedback document", users_form_answer_feedback_path(award, format: :pdf)
+            '  so you can better understand our decision. We hope it will help you to improve your future nominations.
+        - else
+          p You will be notified when your feedback is ready.
+    .clear
+br
+br

--- a/app/views/content_only/past_applications/_combined.html.slim
+++ b/app/views/content_only/past_applications/_combined.html.slim
@@ -17,15 +17,6 @@
 
       - if award.not_submitted?
         p The nomination was not submitted on time.
-      - else
-        h4 Feedback
-        - if award.feedback.try(:submitted?)
-          p
-            ' Please
-            = link_to "download and read the feedback document", users_form_answer_feedback_path(award, format: :pdf)
-            '  so you can better understand our decision. We hope it will help you to improve your future nominations.
-        - else
-          p You will be notified when your feedback is ready.
     .clear
 br
 br

--- a/app/views/content_only/past_applications/_download_pdf_link.html.slim
+++ b/app/views/content_only/past_applications/_download_pdf_link.html.slim
@@ -1,2 +1,2 @@
 p
-  = link_to "Download your nomination", users_form_answer_path(award, format: :pdf), "target" => "_blank", "aria-label" => "Download your QAVS nomination"
+  = link_to "Download nomination", users_form_answer_path(award, format: :pdf), "target" => "_blank", "aria-label" => "Download your QAVS nomination"

--- a/app/views/content_only/post_submission/_shortlisted.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted.html.slim
@@ -18,10 +18,7 @@
     .container-split.award-list
       .content-left
         h3
-          = award.application_name.to_s
-          small
-            = award.award_type_full_name
-            '  Award
+          = award.company_or_nominee_name
       .content-right.content-offset-24
         / Nominators don't get any options after submision
         p Please review the actions below to complete your shortlisted nomination.

--- a/app/views/content_only/post_submission/_submitted.html.slim
+++ b/app/views/content_only/post_submission/_submitted.html.slim
@@ -6,8 +6,7 @@
         = award.company_or_nominee_name
     .content-right.content-offset-24
       p
-        ' Your
-        => link_to "nomination", edit_form_url(award.id)
+        => link_to "View nomination", edit_form_url(award.id)
     .clear
 br
 br

--- a/app/views/content_only/post_submission/_submitted.html.slim
+++ b/app/views/content_only/post_submission/_submitted.html.slim
@@ -3,10 +3,7 @@
   .container-split.award-list
     .content-left
       h3
-        = award.application_name
-        small
-          = award.award_type_full_name
-          '  Award
+        = award.company_or_nominee_name
     .content-right.content-offset-24
       p
         ' Your

--- a/app/views/content_only/post_submission/_unsuccessful.html.slim
+++ b/app/views/content_only/post_submission/_unsuccessful.html.slim
@@ -16,10 +16,7 @@
     .container-split.award-list
       .content-left
         h3
-          = award.application_name
-          small
-            = award.award_type_full_name
-            '  Award
+          = award.company_or_nominee_name
       .content-right.content-offset-24
         / Nominators don't get any options after submision
         - if award.not_submitted?

--- a/app/views/content_only/post_submission/_winners.html.slim
+++ b/app/views/content_only/post_submission/_winners.html.slim
@@ -31,10 +31,7 @@
     .container-split.award-list
       .content-left
         h3
-          = award.application_name
-          small
-            = award.award_type_full_name
-            '  Award
+          = award.company_or_nominee_name
       .content-right.content-offset-24
         / Nominators don't get any options after submision
           - if award.press_summary.present? && award.press_summary.submitted?

--- a/app/views/feedbacks/show.html.slim
+++ b/app/views/feedbacks/show.html.slim
@@ -7,7 +7,7 @@ header.page-header.group.page-header-wider
   article.group role="article"
     .inner
       p
-        ' This is for feedback, not support. If you need help, please ring us on 0207 271 6206. Alternatively, email us at
+        ' This is for feedback, not support. If you need help, please call us on 0207 271 6206. Alternatively, email us at
         = mail_to "queensaward@dcms.gov.uk"
 
       = simple_form_for @feedback, url: feedback_path do |f|

--- a/app/views/form_award_eligibilities/_steps_progress_bar.html.slim
+++ b/app/views/form_award_eligibilities/_steps_progress_bar.html.slim
@@ -21,7 +21,7 @@
 
     li.divider
     li.sidebar-helpline
-      ' Need help? Ring us on
+      ' Need help? Call us on
       br
       ' 0207 271 6206
       span.helpline-space

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -120,7 +120,7 @@
 
         - unless landing_page?
           p.footer-helpline
-            ' Need help? Ring us on
+            ' Need help? Call us on
             strong 0207 271 6206
             ' . Alternatively, email us at
             = link_to "queensaward@dcms.gov.uk", "mailto:queensaward@dcms.gov.uk"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -51,11 +51,11 @@
             ul#proposition-links class="#{show_navigation_links? == false ? "right-align" : ""}"
               - if show_navigation_links?
                 li
-                  = link_to "Nominations", dashboard_path
+                  = link_to "Nominations", dashboard_path, class: current_class?(dashboard_path)
                 li
-                  = link_to "Useful information", useful_information_account_path
+                  = link_to "Useful information", useful_information_account_path, class: current_class?(useful_information_account_path)
                 li
-                  = link_to "Account details", password_settings_account_path
+                  = link_to "Account details", password_settings_account_path, class: current_class?(password_settings_account_path)
               li
                 = link_to "Sign out", destroy_user_session_path, method: :delete
 

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -42,7 +42,7 @@
 
     li.divider
     li.sidebar-helpline
-      ' Need help? Ring us on
+      ' Need help? Call us on
       br
       ' 0207 271 6206
       span.helpline-space

--- a/app/views/shared/_application_awards_status.html.slim
+++ b/app/views/shared/_application_awards_status.html.slim
@@ -16,11 +16,5 @@
 /* link:      Download PDF
 /* action:    Download PDF of your application
 
-ul.applications-list
-  li
-    h3
-      ' QAVS
-    small
-      ' You can apply for multiple Promoting Opportunity Awards
-    .pull-right
-      = link_to "New nomination", apply_qavs_award_path, "aria-label" => "New nomination"
+.pull-left
+  = link_to "Start a new nomination", apply_qavs_award_path, "aria-label" => "New nomination", class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     registrations: "users/registrations",
-    confirmations: "users/confirmations"
+    confirmations: "users/confirmations",
+    sessions: "sessions"
   }
 
   devise_for :admins, controllers: {

--- a/public/404.html
+++ b/public/404.html
@@ -842,7 +842,7 @@
             </div>
           </div>
           <p class="footer-helpline">
-            Need help? Ring us on <strong>0207 271 6206</strong>. Alternatively, email us at <a href="mailto:queensaward@dcms.gov.uk">queensaward@dcms.gov.uk</a>
+            Need help? Call us on <strong>0207 271 6206</strong>. Alternatively, email us at <a href="mailto:queensaward@dcms.gov.uk">queensaward@dcms.gov.uk</a>
           </p>
         </main>
       </div>

--- a/public/422.html
+++ b/public/422.html
@@ -849,7 +849,7 @@
             </div>
           </div>
           <p class="footer-helpline">
-            Need help? Ring us on <strong>0207 271 6206</strong>. Alternatively, email us at <a href="mailto:queensaward@dcms.gov.uk">queensaward@dcms.gov.uk</a>
+            Need help? Call us on <strong>0207 271 6206</strong>. Alternatively, email us at <a href="mailto:queensaward@dcms.gov.uk">queensaward@dcms.gov.uk</a>
           </p>
         </main>
       </div>

--- a/spec/acceptance/steps/application_form_creation_steps.rb
+++ b/spec/acceptance/steps/application_form_creation_steps.rb
@@ -16,12 +16,12 @@ step "I go to dashboard" do
 end
 
 step "I should see application link" do
-  expect(page).to have_link("New nomination", href:'/apply_qavs_award')
+  expect(page).to have_link("Start a new nomination", href:'/apply_qavs_award')
 end
 
 step "I create nomination" do
   step "I go to dashboard"
-  click_link "New nomination", href: '/apply_qavs_award'
+  click_link "Start a new nomination", href: '/apply_qavs_award'
   click_button "Start eligibility questionnaire"
   click_button "Continue" #eligibility step
 end

--- a/spec/features/admin/form_answers/create_spec.rb
+++ b/spec/features/admin/form_answers/create_spec.rb
@@ -16,7 +16,7 @@ feature "Admin creates nomination", js: true do
 
     within_window application_window do
       # User interface
-      click_link("New nomination")
+      click_link("Start a new nomination")
       click_button("Mark as eligible and create nomination")
 
       expect(page).to have_content("A. Nominee")

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -13,7 +13,7 @@ describe "Eligibility forms" do
   context "innovation" do
     it "process the eligibility form" do
       visit dashboard_path
-      click_link("New nomination")
+      click_link("Start a new nomination")
 
       click_button("Start eligibility questionnaire")
       form_choice(["Yes", "Yes", "Yes", /Business/, /Product/, "Yes", "No"])

--- a/spec/features/users/post_submission_dashboard_spec.rb
+++ b/spec/features/users/post_submission_dashboard_spec.rb
@@ -9,13 +9,14 @@ describe  "User sees the post submission dashboard" do
   before do
     form_answer.state_machine.submit(user)
     login_as user
+    @current_year = AwardYear.current.year
   end
 
   describe "visits the post submission dashboard", js: true do
     it "sees applications properly" do
       visit dashboard_path
       expect(page).to have_content"Edit nomination"
-      expect(page).to have_content("Current Nominations")
+      expect(page).to have_content("#{@current_year} award nominations (current)")
 
       settings.destroy
       settings = create(:settings, :expired_submission_deadlines, award_year_id: AwardYear.current.id)

--- a/spec/features/users/pre_submission_dashboard_spec.rb
+++ b/spec/features/users/pre_submission_dashboard_spec.rb
@@ -12,7 +12,7 @@ describe  "User sees the pre submission dashboard" do
   describe "when visits the dashboard after some awards are opened" do
     it "should see message confirming that" do
       visit dashboard_path
-      expect(page).to have_link("New nomination", href: "/apply_qavs_award")
+      expect(page).to have_link("Start a new nomination", href: "/apply_qavs_award")
     end
   end
 end


### PR DESCRIPTION
https://app.asana.com/0/1200175839265057/1200311190679934
https://drive.google.com/file/d/1Kr1V_4tj7WYh_tWCBs16YOiysDsM1LPt/view

Adds active link colour for menu.
Removes sign in flash notice.

Displays group name (or ID when not yet given).
Groups unsuccessful and successful past nominations and removes feedback section.
<img width="871" alt="Screenshot 2021-07-16 at 15 59 10" src="https://user-images.githubusercontent.com/65811538/126289261-21c5a0fd-6dde-4b95-af75-8d6c06881e81.png">

Changes headline message for current users post deadline
<img width="926" alt="Screenshot 2021-07-16 at 15 55 55" src="https://user-images.githubusercontent.com/65811538/126290349-01355ec9-cfe0-4077-b61a-3e2872eec589.png">

Changes headline message for new users post deadline
<img width="994" alt="Screenshot 2021-07-16 at 15 56 14" src="https://user-images.githubusercontent.com/65811538/126290501-68903cce-8d88-4a3c-8788-ee287b89c09e.png">


Adds govuk banner for submission deadline (but not used until toolkit upgrade).
Copy text tweaks.