### PR TITLE
admin dashboard UI additions

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -282,11 +282,15 @@ ready = ->
         show_button = true
 
     if show_button
-      $(".bulk-assign-assessors-link").addClass("show-button")
-      $(".bulk-assign-lieutenants-link").addClass("show-button")
+      $(".bulk-assignment-container").addClass("show-container")
+
+      selected_count = $('input[type=checkbox].form-answer-check:checked').length
+      if selected_count > 1
+        $('.nominations-checked-total').text(`selected_count` +' groups selected')
+      else
+        $('.nominations-checked-total').text(`selected_count` +' group selected')
     else
-      $(".bulk-assign-assessors-link").removeClass("show-button")
-      $(".bulk-assign-lieutenants-link").removeClass("show-button")
+      $(".bulk-assignment-container").removeClass("show-container")
 
 changeRagStatus = ->
   $(document).on "click", ".btn-rag .dropdown-menu a", (e) ->

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -582,12 +582,12 @@
   margin-bottom: 20px;
 }
 
-.bulk-assign-assessors-link, .bulk-assign-lieutenants-link {
+.bulk-assignment-container {
   position: relative;
   left: -9999px;
   margin-top: 10px;
 
-  &.show-button {
+  &.show-container {
     left: 0;
   }
 
@@ -598,6 +598,10 @@
   }
 }
 
+.nominations-checked-total {
+  display: inline;
+  margin-right: 20px;
+}
 
 .bulk-assign-assessors-form, .bulk-assign-lieutenants-form {
   max-width: 755px;

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -104,6 +104,10 @@
     font-style: italic;
   }
 
+  .assigned {
+    color: $button-colour;
+  }
+
   .icon-unflagged {
     display: none;
   }

--- a/app/controllers/admin/lieutenant_assignment_collections_controller.rb
+++ b/app/controllers/admin/lieutenant_assignment_collections_controller.rb
@@ -4,18 +4,12 @@ class Admin::LieutenantAssignmentCollectionsController < Admin::BaseController
     authorize @lieutenant_assignment_collection, :create?
 
     @lieutenant_assignment_collection.subject = current_subject
-    total_checked = @lieutenant_assignment_collection.form_answer_ids.split(",").length
-    if @lieutenant_assignment_collection.save
-      notification = if total_checked > 1
-                       "Groups have"
-                     else
-                       "Group has"
-                     end.concat " been assigned to the Lord Lieutenancy office."
-    end
+
+    @lieutenant_assignment_collection.save
 
     respond_to do |format|
       format.html do
-        flash[:notice] = notification
+        flash[:notice] = @lieutenant_assignment_collection.notice_message
         flash[:error] = @lieutenant_assignment_collection.errors.full_messages.to_sentence
         redirect_back(fallback_location: root_path)
       end

--- a/app/controllers/admin/lieutenant_assignment_collections_controller.rb
+++ b/app/controllers/admin/lieutenant_assignment_collections_controller.rb
@@ -4,10 +4,18 @@ class Admin::LieutenantAssignmentCollectionsController < Admin::BaseController
     authorize @lieutenant_assignment_collection, :create?
 
     @lieutenant_assignment_collection.subject = current_subject
-    @lieutenant_assignment_collection.save
+    total_checked = @lieutenant_assignment_collection.form_answer_ids.split(",").length
+    if @lieutenant_assignment_collection.save
+      notification = if total_checked > 1
+                       "Groups have"
+                     else
+                       "Group has"
+                     end.concat " been assigned to the Lord Lieutenancy office."
+    end
 
     respond_to do |format|
       format.html do
+        flash[:notice] = notification
         flash[:error] = @lieutenant_assignment_collection.errors.full_messages.to_sentence
         redirect_back(fallback_location: root_path)
       end

--- a/app/models/lieutenant_assignment_collection.rb
+++ b/app/models/lieutenant_assignment_collection.rb
@@ -21,6 +21,14 @@ class LieutenantAssignmentCollection
     form_answers.update_all(ceremonial_county_id: ceremonial_county_id)
   end
 
+  def notice_message
+    if ids.length > 1
+      "Groups have"
+    else
+      "Group has"
+    end.concat " been assigned to the Lord Lieutenancy office."
+  end
+
   private
 
   def form_answers

--- a/app/views/admin/form_answers/_bulk_assignment.html.slim
+++ b/app/views/admin/form_answers/_bulk_assignment.html.slim
@@ -29,4 +29,6 @@
               .clear
 
   .if-no-js-hide
-    button.mm-modal__btn.bulk-assign-lieutenants-link data-micromodal-trigger="modal-bulk-assign-lieutenants" Bulk assign to Lord Lieutenancy office
+    .bulk-assignment-container
+      .nominations-checked-total
+      button.mm-modal__btn.bulk-assign-lieutenants-link data-micromodal-trigger="modal-bulk-assign-lieutenants" Bulk assign to Lord Lieutenancy office

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -55,3 +55,5 @@ h1.admin-page-heading
     .col-xs-12.text-right
       = paginate @form_answers
       .clear
+
+= render("admin/form_answers/bulk_assignment")

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -6,11 +6,13 @@ table.table.applications-table
           = check_box_tag :check_all
       th.sortable width="450"
         = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
-      th.sortable width="130"
+      th.sortable width="140"
         = sort_link f, "Reference", @search, :urn, disabled: @search.query?
       th width="250"
         | Status
-      th width="200"
+      th width="100"
+        | Postcode
+      th width="250"
         | Lord Lieutenancy office
       th width="200"
         | Type of group

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -6,6 +6,8 @@ table.table.applications-table
           = check_box_tag :check_all
       th.sortable width="450"
         = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
+      th.sortable width="120"
+        = sort_link f, "Reference", @search, :urn, disabled: @search.query?
       th width="250"
         | Status
       th width="200"

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -6,7 +6,7 @@ table.table.applications-table
           = check_box_tag :check_all
       th.sortable width="450"
         = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
-      th.sortable width="120"
+      th.sortable width="130"
         = sort_link f, "Reference", @search, :urn, disabled: @search.query?
       th width="250"
         | Status

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -16,6 +16,7 @@
       - else
         span.urn-not-generated Not generated
     td = obj.dashboard_status(current_admin.class.name)
+    td = obj.document["nominee_address_postcode"]
     td
       - if obj.ceremonial_county.present?
         = obj.ceremonial_county.name

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -10,13 +10,18 @@
         = link_to polymorphic_url([namespace_name, obj], search: params[:search]), aria: { label: "View submitted nomination, nominee name not yet specified" } do
           em
             ' Not yet specified
+    td
+      - if obj.urn.present?
+        = link_to obj.urn, polymorphic_url([namespace_name, obj], search: params.permit[:search])
+      - else
+        span.urn-not-generated Not yet generated
     td = obj.dashboard_status(current_admin.class.name)
     td
-      -if obj.ceremonial_county.present?
+      - if obj.ceremonial_county.present?
         = obj.ceremonial_county.name
-      -elsif obj.document["nominee_ceremonial_county"].present?
+      - elsif obj.document["nominee_ceremonial_county"].present?
         = CeremonialCounty.find(obj.document["nominee_ceremonial_county"]).name
-      -else
+      - else
        'Not stated
     td = NomineeActivityHelper.lookup_label_for_activity(obj.nominee_activity.to_sym)
     td

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -14,7 +14,7 @@
       - if obj.urn.present?
         = link_to obj.urn, polymorphic_url([namespace_name, obj], search: params.permit[:search])
       - else
-        span.urn-not-generated Not yet generated
+        span.urn-not-generated Not generated
     td = obj.dashboard_status(current_admin.class.name)
     td
       - if obj.ceremonial_county.present?

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -20,6 +20,8 @@
     td
       - if obj.ceremonial_county.present?
         = obj.ceremonial_county.name
+        br
+        span.assigned Assigned
       - elsif obj.document["nominee_ceremonial_county"].present?
         = CeremonialCounty.find(obj.document["nominee_ceremonial_county"]).name
       - else

--- a/spec/features/admin/form_answers/bulk_lieutenants_assignment_spec.rb
+++ b/spec/features/admin/form_answers/bulk_lieutenants_assignment_spec.rb
@@ -25,7 +25,7 @@ describe "Admin assigns lieutenants", %(
     it "assigns the lieutenant" do
       first("#check_all").set(true)
 
-      find("button", text: "Bulk assign to Lord Lieutenancy office").click
+      click_button("Bulk assign to Lord Lieutenancy office", match: :first)
       find(:css, "#modal-bulk-assign-lieutenants").should be_visible
 
       select ceremonial_county_2.name, from: "Select Lord Lieutenancy office"


### PR DESCRIPTION
https://drive.google.com/file/d/1soVr-PhHbDhAZdTBbjjOLqYNwhgfUYZM/view
Adds column for URN and displays not generated when urn not found.
Adds column for nominee postcode.
Displays an assigned tag below ceremonial county once assigned to lieutenancy.
<img width="1206" alt="Screenshot 2021-07-22 at 20 41 01" src="https://user-images.githubusercontent.com/65811538/126700290-feaf2df3-55a0-47f8-bc62-585818861463.png">

Displays the checkbox selected total alongside bulk assignment buttons.
<img width="1167" alt="Screenshot 2021-07-22 at 20 19 31" src="https://user-images.githubusercontent.com/65811538/126700445-768e62fa-1ebb-4392-986f-a5c7b86eb659.png">

Repeats bulk assignment component below table.
<img width="1220" alt="Screenshot 2021-07-22 at 20 56 36" src="https://user-images.githubusercontent.com/65811538/126701753-c42fafe7-73c9-4ddd-b2f6-c3637a682d9c.png">

Adds flash notice after assigning lieutenancy
<img width="1217" alt="Screenshot 2021-07-23 at 09 55 47" src="https://user-images.githubusercontent.com/65811538/126759519-dbe6362e-7153-4638-b4e1-e98523047dca.png">
