### PR TITLE
finds invite by id instead of token

### DIFF
--- a/app/controllers/group_leader/dashboard_controller.rb
+++ b/app/controllers/group_leader/dashboard_controller.rb
@@ -2,6 +2,12 @@ class GroupLeader::DashboardController < GroupLeader::BaseController
   def show
     authorize :group_leader_dashboard, :show?
     @citation = current_subject.form_answer.citation
-    @invite = current_subject.form_answer.palace_invite
+    @invite = palace_invite
+  end
+
+  private
+
+  def palace_invite
+    current_subject.form_answer.palace_invite || PalaceInvite.create!(form_answer: current_subject.form_answer, email: current_subject.email)
   end
 end

--- a/app/controllers/palace_invites_controller.rb
+++ b/app/controllers/palace_invites_controller.rb
@@ -8,10 +8,10 @@ class PalaceInvitesController < ApplicationController
       log_event
       if @invite.submitted?
         flash.notice = "Palace Attendees details are successfully submitted!"
-        redirect_to edit_palace_invite_url(id: @invite.token)
+        redirect_to group_leader_root_path
       else
         flash.notice = "Attendee details have been successfully updated"
-        redirect_to edit_palace_invite_url(id: @invite.token)
+        redirect_to group_leader_root_path
       end
     else
       render :edit
@@ -21,7 +21,7 @@ class PalaceInvitesController < ApplicationController
   private
 
   def load_invite
-    @invite = PalaceInvite.find_by_token(params[:id]) or raise ActionController::RoutingError.new("Not Found")
+    @invite = PalaceInvite.find(params[:id]) or raise ActionController::RoutingError.new("Not Found")
     @invite_form = PalaceInviteForm.new(@invite)
   end
 

--- a/app/forms/palace_invite_form.rb
+++ b/app/forms/palace_invite_form.rb
@@ -34,6 +34,11 @@ class PalaceInviteForm
     @attendees ||= invite.palace_attendees.to_a
   end
 
+  def build_attendees
+    @attendees = []
+    2.times { @attendees << invite.palace_attendees.build }
+  end
+
   def build_palace_attendee
     @attendees ||= []
     @attendees << invite.palace_attendees.build

--- a/app/views/group_leader/dashboard/show.html.slim
+++ b/app/views/group_leader/dashboard/show.html.slim
@@ -72,7 +72,7 @@
       =< AwardYear.current.year+1
       | . You must provide the attendee details and your preferred day for attending by
       =< deadline_for("buckingham_palace_attendees_details", "%l %P, %-d %B %Y.")
-    = link_to "Provide details for Royal Garden Party", edit_palace_invite_url(id: @invite.token), class: "govuk-button govuk-button--start"
+    = link_to "Provide details for Royal Garden Party", edit_palace_invite_url(id: @invite.id), class: "govuk-button govuk-button--start"
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
     h3.govuk-heading-m

--- a/app/views/palace_invites/_form.html.slim
+++ b/app/views/palace_invites/_form.html.slim
@@ -1,12 +1,12 @@
-= simple_form_for @invite_form, as: :palace_invite, url: palace_invite_url(id: @invite.token), html: { class: 'qae-form', method: :patch } do |f|
+= simple_form_for @invite_form, as: :palace_invite, url: palace_invite_url(id: @invite.id), html: { class: 'qae-form', method: :patch } do |f|
 
-  - @invite_form.build_palace_attendee if @invite_form.palace_attendees.none?
+  - @invite_form.build_attendees if @invite_form.palace_attendees.none?
 
   fieldset.question-block.question-group
-    ul.list-add data-need-to-clear-example=true data-add-limit="2" data-default=1
+    ul
       - i = 0
       = f.simple_fields_for :palace_attendees do |ff|
-        .js-add-example.govuk-form-group
+        .govuk-form-group
           - i += 1
           legend.govuk-fieldset__legend
             h3.govuk-heading-m
@@ -15,5 +15,5 @@
               | attendee
           = render "attendee_details", ff: ff, attendee: i
 
-    = f.submit "Submit", class: "govuk-button save-palace-attendees-button"
+    = f.submit "Submit", class: "govuk-button save-palace-attendees-button", name: "submit"
     = link_to "Cancel", group_leader_root_path, class: "govuk-button govuk-button--secondary if-no-js-hide"


### PR DESCRIPTION
Before this commit a palace invite needed to be created before a group leader could log in. This commit changes this by:

- When group leader logs in - if palace invite is not found then created.
- Adds name to submit button to submit instead of update and validations are now run on palace attendees - and changes palace_invited.submitted to true, which is then shown on the group leader dashboard.
- Changes creation of palace attendees to remove javascript and add/remove links. If no attendees are linked to the invite then 2 attendees are created.