### PR TITLE
UI fixes

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -537,7 +537,6 @@ header.page-header aside .inner {
     list-style: none;
     margin: 0 -15px;
     padding: 0;
-    font-size: 0.1px;
     line-height: 0;
 
     &:after {

--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -272,13 +272,28 @@ select.read-only {
 .step-download a {
   display: inline-block;
   position: relative;
-  text-decoration: none;
-  
+  margin-left: 30px;
+
+  &:before {
+    content: " ";
+    display: block;
+    width: 18px;
+    height: 16px;
+    background-image: image-url("icon_download.svg");
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+    background-position: center;
+
+    position: absolute;
+    left: -20px;
+    top: 10px;
+  }
+
   &:focus {
     color: black;
     text-decoration: underline;
   }
-  
+
   svg {
     display: inline-block;
     height: 1.4em;

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -317,7 +317,7 @@ class AwardYears::V2022::QAEForms
             <p class='govuk-hint'>
               The purpose of the Lord-Lieutenant's citation is to summarise the local panel's opinion about the nominated group and to explain the decision to recommend or not recommend it. If the decision is to recommend, then these opinions will be very helpful to the Awarding Committee when making their judgements. The main guidance for Lieutenancies circulated each September provides more advice about drafting the citation, but you might want to bear in the points below when recommending a group to the national assessors:
             </p>
-            <ul class='govuk-list govuk-list--bullet'>
+            <ul class='govuk-list govuk-list--bullet govuk-hint'>
               <li>The citation does not need to repeat the detail provided in the nomination and local assessment report, since the national assessors will have studied this material carefully as well.</li>
               <li>Instead, the citation should try to capture what is exceptional about this particular group. For instance, the impact it has made on local people (particularly if the local context is challenging); the ways in which its work or approach is distinctive or different from other groups doing similar things; anything outstanding about the way the group is run; any exemplary qualities in the volunteers themselves.</li>
               <li>The citation should be around 400-600 words. It should not be longer than that, but don't make it too short either as this is an important opportunity to 'bring the group to life' for the national assessors.</li>

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -344,7 +344,7 @@ class AwardYears::V2022::QAEForms
           required
         end
 
-        submit "Submit assessment" do
+        submit "Submit local assessment" do
           notice %(
             <p class='govuk-hint'>
               If you have answered all the questions, you can submit your assessment now. You will be able to edit it any time before [LIEUTENANT_SUBMISSION_ENDS_TIME].

--- a/app/views/admin/assessors/_list.html.slim
+++ b/app/views/admin/assessors/_list.html.slim
@@ -26,7 +26,7 @@ table.govuk-table
             small.text-muted
               span.visible-lg
                 = assessor.formatted_last_sign_in_at_long
-              span.hidden-lg
+              span class="govuk-!-display-none"
                 = assessor.formatted_last_sign_in_at_short
           td.govuk-table__cell
             - if assessor.confirmed_at.present?

--- a/app/views/admin/users/_list.html.slim
+++ b/app/views/admin/users/_list.html.slim
@@ -34,7 +34,7 @@ table.govuk-table
             small.text-muted
               span.visible-lg
                 = user.formatted_last_sign_in_at_long
-              span.hidden-lg
+              span class="govuk-!-display-none"
                 = user.formatted_last_sign_in_at_short
           td.govuk-table__cell
             - if user.confirmed_at.present?

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -24,7 +24,7 @@
 
         = render 'list', resources: @resources, f: f
 
-        .row
+        .govuk-grid-row
           .col-xs-12.text-right
             = paginate @resources
             .clear

--- a/app/views/form/positions/index.html.slim
+++ b/app/views/form/positions/index.html.slim
@@ -46,5 +46,4 @@ header.page-header.group.page-header-over-sidebar
               ' + Add role
 
     = render "qae_form/steps_progress_bar", current_step: step.title.parameterize
-
     = render "form/supporters/footer", step: step

--- a/app/views/lieutenant/lieutenants/_list.html.slim
+++ b/app/views/lieutenant/lieutenants/_list.html.slim
@@ -1,39 +1,37 @@
-.row
-  .col-xs-12
-    table.table.assessor-table
-      thead
-        tr
-          th.sortable
-            = sort_link f, 'Name', @search, :full_name
-          th.sortable
-            = sort_link f, 'Email', @search, :email
-          th.sortable
-            = sort_link f, 'Signed in on', @search, :last_sign_in_at
-          th.sortable
-            = sort_link f, "Confirmed on", @search, :confirmed_at
-      tbody
-        - if resources.none?
-          tr
-            td.text-center colspan=100
-              br
-              p.p-empty No lieutenants found.
-              br
-        - else
-          - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
-            tr
-              td.td-title
-                = link_to lieutenant.full_name, edit_lieutenant_lieutenant_path(lieutenant), class: 'link-edit-user'
-              td = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
-              td
-                small.text-muted
-                  span.visible-lg
-                    = lieutenant.formatted_last_sign_in_at_long
-                  span.hidden-lg
-                    = lieutenant.formatted_last_sign_in_at_short
-              td
-                - if lieutenant.confirmed_at.present?
-                  small.text-muted
-                    = l lieutenant.confirmed_at, format: :date_at_time
-                - else
-                  small.text-danger
-                    ' Not confirmed
+table.govuk-table
+  thead.govuk-table__head
+    tr.govuk-table__row
+      th.sortable.govuk-table__header scope="col"
+        = sort_link f, 'Name', @search, :full_name
+      th.sortable.govuk-table__header scope="col"
+        = sort_link f, 'Email', @search, :email
+      th.sortable.govuk-table__header scope="col"
+        = sort_link f, 'Signed in on', @search, :last_sign_in_at
+      th.sortable.govuk-table__header scope="col"
+        = sort_link f, "Confirmed on", @search, :confirmed_at
+  tbody.govuk-table__body
+    - if resources.none?
+      tr.govuk-table__row
+        td.text-center colspan=100
+          br
+          p.p-empty No lieutenants found.
+          br
+    - else
+      - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
+        tr.govuk-table__row
+          td.govuk-table__cell.td-title
+            = link_to lieutenant.full_name, edit_lieutenant_lieutenant_path(lieutenant), class: 'link-edit-user'
+          td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
+          td.govuk-table__cell
+            small.text-muted
+              span.visible-lg
+                = lieutenant.formatted_last_sign_in_at_long
+              span class="govuk-!-display-none"
+                = lieutenant.formatted_last_sign_in_at_short
+          td.govuk-table__cell
+            - if lieutenant.confirmed_at.present?
+              small.text-muted
+                = l lieutenant.confirmed_at, format: :date_at_time
+            - else
+              small.text-danger
+                ' Not confirmed

--- a/app/views/lieutenant/lieutenants/create.html.slim
+++ b/app/views/lieutenant/lieutenants/create.html.slim
@@ -1,5 +1,5 @@
 header.page-header
   h1.govuk-heading-xl
-    ' New lieutenant
+    ' New Lord Lieutenancy office user
 
 = render 'form', resource: @resource

--- a/app/views/lieutenant/lieutenants/edit.html.slim
+++ b/app/views/lieutenant/lieutenants/edit.html.slim
@@ -1,5 +1,5 @@
 header.page-header
   h1.govuk-heading-xl
-    ' Edit lieutenant
+    ' Edit Lord Lieutenancy office user
 
 = render 'form', resource: @resource

--- a/app/views/lieutenant/lieutenants/index.html.slim
+++ b/app/views/lieutenant/lieutenants/index.html.slim
@@ -1,25 +1,28 @@
-= simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
-  .row
-    .col-md-4.col-sm-5.col-xs-12
-      .form-group.search-input
-        = f.input :query, label: false, input_html: { class: "form-control", placeholder: "Search...", type: "search" }
-        = submit_tag :submit, class: 'search-submit'
+.dashboard
+  h1.govuk-heading-xl
+    | Lord Lieutenancy Office Users
+  = simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
+    .govuk-grid-row
+      .govuk-grid-column-one-third
+        .form-group.search-input
+          = f.input :query, label: false, input_html: { class: "form-control", placeholder: "Search...", type: "search" }
+          = submit_tag :submit, class: 'search-submit'
 
-    .col-md-3.col-sm-4.col-xs-12.pull-right.text-right
-      = link_to new_lieutenant_lieutenant_path, class: 'new-user govuk-button govuk-button--secondary btn-secondary btn-md' do
-        = "+ Add lieutenant"
-  .clear
+      .govuk-grid-column-two-thirds.text-right
+        = link_to new_lieutenant_lieutenant_path, class: 'new-user govuk-button' do
+          = "+ Add Lord Lieutenancy Office user"
+    .clear
 
-  - if @search.query?
-    .well.search-text
-      p.govuk-body
-        = "Search results for '#{@search.query}'"
-        small
-          = link_to "(Clear search)", [:lieutenant, :lieutenants], class: "govuk-button btn-link"
+    - if @search.query?
+      .well.search-text
+        p.govuk-body
+          = "Search results for '#{@search.query}'"
+          small
+            = link_to "(Clear search)", [:lieutenant, :lieutenants], class: "govuk-button btn-link"
 
-  = render 'list', resources: @resources, f: f
+    = render 'list', resources: @resources, f: f
 
-  .row
-    .col-xs-12.text-right
-      = paginate @resources
-      .clear
+    .row
+      .col-xs-12.text-right
+        = paginate @resources
+        .clear

--- a/app/views/lieutenant/lieutenants/index.html.slim
+++ b/app/views/lieutenant/lieutenants/index.html.slim
@@ -3,12 +3,12 @@
     | Lord Lieutenancy Office Users
   = simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
     .govuk-grid-row
-      .govuk-grid-column-one-third
-        .form-group.search-input
+      .govuk-grid-column-two-thirds
+        .form-group.search-input.govuk-grid-column-one-half
           = f.input :query, label: false, input_html: { class: "form-control", placeholder: "Search...", type: "search" }
-          = submit_tag :submit, class: 'search-submit'
+          / = submit_tag :submit, text: "Search users", class: 'search-submit'
 
-      .govuk-grid-column-two-thirds.text-right
+      .govuk-grid-column-one-third.text-right
         = link_to new_lieutenant_lieutenant_path, class: 'new-user govuk-button' do
           = "+ Add Lord Lieutenancy Office user"
     .clear

--- a/app/views/lieutenant/lieutenants/index.html.slim
+++ b/app/views/lieutenant/lieutenants/index.html.slim
@@ -1,6 +1,6 @@
 .dashboard
   h1.govuk-heading-xl
-    | Lord Lieutenancy Office Users
+    | Lord Lieutenancy office users
   = simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
     .govuk-grid-row
       .govuk-grid-column-two-thirds

--- a/app/views/lieutenant/lieutenants/index.html.slim
+++ b/app/views/lieutenant/lieutenants/index.html.slim
@@ -9,8 +9,7 @@
           / = submit_tag :submit, text: "Search users", class: 'search-submit'
 
       .govuk-grid-column-one-third.text-right
-        = link_to new_lieutenant_lieutenant_path, class: 'new-user govuk-button' do
-          = "+ Add Lord Lieutenancy Office user"
+        = link_to "+ Add Lord Lieutenancy Office user", new_lieutenant_lieutenant_path, class: 'new-user govuk-button', id: 'add-lieutenant'
     .clear
 
     - if @search.query?

--- a/app/views/lieutenant/lieutenants/new.html.slim
+++ b/app/views/lieutenant/lieutenants/new.html.slim
@@ -1,5 +1,5 @@
 header.page-header
   h1.govuk-heading-xl
-    ' New lieutenant
+    ' New Lord Lieutenancy office user
 
 = render 'form', resource: @resource

--- a/app/views/qae_form/_download_pdf.html.slim
+++ b/app/views/qae_form/_download_pdf.html.slim
@@ -1,0 +1,2 @@
+.govuk-body
+  | Hello

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -4,8 +4,8 @@ footer
       - if current_form_is_editable? || (current_lieutenant && step.local_assessment?)
         - dashboard_link = current_subject.is_a?(Lieutenant) ? lieutenant_form_answer_url(@form_answer) : dashboard_url
         li.save-quit-link
-          - button_class = (current_subject.is_a?(Lieutenant) && current_subject.role.advanced?) ? "govuk-button govuk-button--secondary" : "govuk-button"
-          - button_text = (current_subject.is_a?(Lieutenant) && current_subject.role.advanced?) ? "Save and come back later" : "Save local assessment"
+          - button_class = (current_subject.is_a?(Lieutenant) && current_subject.role.regular?) ?  "govuk-button" : "govuk-button govuk-button--secondary"
+          - button_text = (current_subject.is_a?(Lieutenant) && current_subject.role.regular?) ? "Save local assessment" : "Save and come back later"
           span.if-js-hide
             = button_tag button_text, class: "#{ button_class } save-quit-link btn", value: "redirect", name: "next_action", type: "submit", data: { url: dashboard_link }
           span.if-no-js-hide

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -1,25 +1,6 @@
 footer
   nav.pagination.no-border class="#{'pagination-alternative' unless step.next}" aria-label="Pagination for step #{step.index + 1}"
     ul.group
-      - if step.previous
-        li.previous.previous-alternate.js-step-link data-step="step-#{step.previous.title.parameterize}"
-          - back_url = current_user ? edit_form_url(step: step.previous.title.parameterize) : edit_lieutenant_form_answer_url(@form_answer, step: step.previous.title.parameterize)
-          = link_to back_url, rel: "prev", title: "Navigate to previous part", "aria-label" => "Back to #{step.previous.title}", class: 'govuk-button govuk-button--secondary' do
-            span.pagination-label
-              | Back
-            /span class="pagination-part-title"
-              = step.previous.title
-      - else
-        li.previous.previous-alternate
-          - aria_label = "Back to step " + step.index.to_s
-
-          - if step.index == 0
-            - aria_label = "Back to Useful Application Information page"
-
-          = link_to [:award_info, @form_answer.award_type.to_sym, form_id: @form_answer.id], rel: "prev", title: aria_label, "aria-label" => aria_label, class: "govuk-button govuk-button--secondary" do
-            span.pagination-label
-              | Back
-
       - if current_form_is_editable? || (current_lieutenant && step.local_assessment?)
         - dashboard_link = current_subject.is_a?(Lieutenant) ? lieutenant_form_answer_url(@form_answer) : dashboard_url
         li.save-quit-link
@@ -41,3 +22,21 @@ footer
           li.submit.qae-form
             button type="submit" name="submit" value="true" class="govuk-button #{step.submit.style.presence}"
               = step.submit.text
+
+    - if step.previous
+      .previous.previous-alternate.js-step-link data-step="step-#{step.previous.title.parameterize}"
+        - back_url = current_user ? edit_form_url(step: step.previous.title.parameterize) : edit_lieutenant_form_answer_url(@form_answer, step: step.previous.title.parameterize)
+        = link_to back_url, rel: "prev", title: "Navigate to previous part", "aria-label" => "Back to #{step.previous.title}", class: 'govuk-back-link govuk-!-font-size-19' do
+          span.pagination-label
+            | Go back to previous page
+
+    - else
+      .previous.previous-alternate
+        - aria_label = "Back to step " + step.index.to_s
+
+        - if step.index == 0
+          - aria_label = "Back to Useful Application Information page"
+
+        = link_to [:award_info, @form_answer.award_type.to_sym, form_id: @form_answer.id], rel: "prev", title: aria_label, "aria-label" => aria_label, class: "govuk-back-link govuk-!-font-size-19" do
+          span.pagination-label
+            | Back

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -4,10 +4,12 @@ footer
       - if current_form_is_editable? || (current_lieutenant && step.local_assessment?)
         - dashboard_link = current_subject.is_a?(Lieutenant) ? lieutenant_form_answer_url(@form_answer) : dashboard_url
         li.save-quit-link
+          - button_class = current_lieutenant.role.advanced? ? "govuk-button govuk-button--secondary" : "govuk-button"
+          - button_text = current_lieutenant.role.advanced? ? "Save and come back later" : "Save local assessment"
           span.if-js-hide
-            = button_tag "Save and come back later", class: "govuk-button save-quit-link btn", value: "redirect", name: "next_action", type: "submit", data: { url: dashboard_link }
+            = button_tag button_text, class: "#{ button_class } save-quit-link btn", value: "redirect", name: "next_action", type: "submit", data: { url: dashboard_link }
           span.if-no-js-hide
-            = link_to "Save and come back later", dashboard_link, class: " govuk-button govuk-button--secondary js-save-and-come-back"
+            = link_to button_text, dashboard_link, class: "#{ button_class } js-save-and-come-back"
 
       - if step.next_for(@form_answer, current_form_user)
         li.submit.js-next-link.js-step-link data-step="step-#{step.next.title.parameterize}"

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -4,8 +4,8 @@ footer
       - if current_form_is_editable? || (current_lieutenant && step.local_assessment?)
         - dashboard_link = current_subject.is_a?(Lieutenant) ? lieutenant_form_answer_url(@form_answer) : dashboard_url
         li.save-quit-link
-          - button_class = current_lieutenant.role.advanced? ? "govuk-button govuk-button--secondary" : "govuk-button"
-          - button_text = current_lieutenant.role.advanced? ? "Save and come back later" : "Save local assessment"
+          - button_class = (current_subject.is_a?(Lieutenant) || current_subject.role.advanced?) ? "govuk-button govuk-button--secondary" : "govuk-button"
+          - button_text = (current_subject.is_a?(Lieutenant) || current_subject.role.advanced?) ? "Save and come back later" : "Save local assessment"
           span.if-js-hide
             = button_tag button_text, class: "#{ button_class } save-quit-link btn", value: "redirect", name: "next_action", type: "submit", data: { url: dashboard_link }
           span.if-no-js-hide

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -4,8 +4,8 @@ footer
       - if current_form_is_editable? || (current_lieutenant && step.local_assessment?)
         - dashboard_link = current_subject.is_a?(Lieutenant) ? lieutenant_form_answer_url(@form_answer) : dashboard_url
         li.save-quit-link
-          - button_class = (current_subject.is_a?(Lieutenant) || current_subject.role.advanced?) ? "govuk-button govuk-button--secondary" : "govuk-button"
-          - button_text = (current_subject.is_a?(Lieutenant) || current_subject.role.advanced?) ? "Save and come back later" : "Save local assessment"
+          - button_class = (current_subject.is_a?(Lieutenant) && current_subject.role.advanced?) ? "govuk-button govuk-button--secondary" : "govuk-button"
+          - button_text = (current_subject.is_a?(Lieutenant) && current_subject.role.advanced?) ? "Save and come back later" : "Save local assessment"
           span.if-js-hide
             = button_tag button_text, class: "#{ button_class } save-quit-link btn", value: "redirect", name: "next_action", type: "submit", data: { url: dashboard_link }
           span.if-no-js-hide

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -36,15 +36,11 @@
 
     - unless QAE.hide_pdf_links?
       li.divider
-      li.step-past.step-download
+      li.govuk-body.step-past.step-download
         - if current_user
-          = link_to users_form_answer_path(@form_answer, format: :pdf)
-            = render "content_only/download_icon"
-            ' Download your nomination (PDF)
+          = link_to "Download your nomination (PDF)", users_form_answer_path(@form_answer, format: :pdf), class: "download-pdf-link govuk-link"
         - else
-          = link_to lieutenant_form_answer_path(@form_answer, format: :pdf)
-            = render "content_only/download_icon"
-            ' Download nomination and local assessment form (PDF)
+          = link_to "Download nomination and local assessment form (PDF)", lieutenant_form_answer_path(@form_answer, format: :pdf), class: "download-pdf-link govuk-link"
 
     li.divider
     li.sidebar-helpline.govuk-body

--- a/app/views/qae_form/show.html.slim
+++ b/app/views/qae_form/show.html.slim
@@ -12,7 +12,7 @@ form.qae-form.award-form data-autosave-url=save_form_url(@form_answer) action=sa
 
   .steps-progress-container.min-height-800
     = render "qae_form/steps_progress_bar", current_step: params[:step]
-    
+
     .steps-progress-content
       - if @form_answer.validator_errors && @form_answer.validator_errors["supporters"].present?
         .govuk-error-summary aria-labelledby="letters-of-support-error-title" role="alert" tabindex="-1" data-module="govuk-error-summary"

--- a/spec/features/lieutenant/lieutenant_management_spec.rb
+++ b/spec/features/lieutenant/lieutenant_management_spec.rb
@@ -14,7 +14,7 @@ describe "Lieutenant: Lieutenant management" do
   it "can create a lieutenant" do
     visit lieutenant_lieutenants_path
 
-    click_link "+ Add lieutenant"
+    click_link "add-lieutenant"
 
     fill_in "First name", with: "LL"
     fill_in "Last name", with: "KK"


### PR DESCRIPTION
- applies govuk styling to lieutenants/lieutenants#index
- applies govuk hidden style to span on user index pages
- updates headers for lieutenants pages

![Screenshot 2021-08-13 at 11 47 06](https://user-images.githubusercontent.com/65811538/129346469-489d8b89-53b2-42e8-9493-f1563bd85b85.png)

- adds hint styling to bullet points in citation hint
- uses govuk back link styling for back links
- displays different copy for submit button for a regular lieutenant

<img width="654" alt="Screenshot 2021-08-13 at 16 13 18" src="https://user-images.githubusercontent.com/65811538/129380725-b7c94570-b030-4fc6-ad03-3e35dc104250.png">

- displays different copy for submit button for an advanced lieutenant

<img width="637" alt="Screenshot 2021-08-13 at 16 13 40" src="https://user-images.githubusercontent.com/65811538/129380801-db1f73f1-2b3b-4cc5-9c77-c728f92117a6.png">



