### PR TITLE
group leader UI tweaks

### DIFF
--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1,7 +1,7 @@
 $black-true: #000;
 
 legend {
-  margin: 0 !important;
+ 
 
   &.light {
     font-weight: 400;
@@ -134,7 +134,7 @@ h2 > .boolean.control-label {
   appearance: none;
 
   @include core-19;
-  
+
   border: 1px solid #bbb;
   min-width: 8em;
   margin: 0;
@@ -1312,7 +1312,7 @@ fieldset.account-contact-preferences-other-ops {
 .other-organization-type {
 
   max-width: 465px !important;
-  
+
   input {
     width: 100% !important;
     display: block;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -137,7 +137,7 @@ $(".custom-select").each(function() {
 
   AccessibleAutocomplete.enhanceSelectElement({
     selectElement: field,
-    showAllValues: true, 
+    showAllValues: true,
     dropdownArrow: function() {
       return "<span class='autocomplete__arrow'></span>";
     }
@@ -158,3 +158,7 @@ for (let i = 0; i < 2; i++) {
   });
 };
 
+$("#accept-award").on('click', function() {
+  $('.citation').removeClass('govuk-!-display-none')
+  $('.award-acceptance-container').addClass('govuk-!-display-none')
+})

--- a/app/views/group_leader/citations/edit.html.slim
+++ b/app/views/group_leader/citations/edit.html.slim
@@ -8,4 +8,15 @@
     p.govuk-body
       | This information will appear on the certificate, QAVS website and in any media publication. Therefore, please ensure that it is accurate.
 
+    .govuk-form-group
+      fieldset.govuk-fieldset aria-describedby="award-acceptance"
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h1.govuk-fieldset__heading
+            | Do you accept the Queen's Award for Voluntary Service on behalf of your group?
+        .govuk-checkboxes
+          .govuk-checkboxes__item
+            input.govuk-checkboxes__input#accept-award type="checkbox" name="aaccept-award" value="yes"
+            label.govuk-label.govuk-checkboxes__label for="accept-award"
+              | I confirm I am happy to accept the award and continue
+
     = render "form"

--- a/app/views/group_leader/citations/edit.html.slim
+++ b/app/views/group_leader/citations/edit.html.slim
@@ -8,15 +8,16 @@
     p.govuk-body
       | This information will appear on the certificate, QAVS website and in any media publication. Therefore, please ensure that it is accurate.
 
-    .govuk-form-group
+    .govuk-form-group.award-acceptance-container
       fieldset.govuk-fieldset aria-describedby="award-acceptance"
         legend.govuk-fieldset__legend.govuk-fieldset__legend--m
           h1.govuk-fieldset__heading
             | Do you accept the Queen's Award for Voluntary Service on behalf of your group?
         .govuk-checkboxes
           .govuk-checkboxes__item
-            input.govuk-checkboxes__input#accept-award type="checkbox" name="aaccept-award" value="yes"
+            input.govuk-checkboxes__input#accept-award type="checkbox" name="accept-award" value="yes"
             label.govuk-label.govuk-checkboxes__label for="accept-award"
               | I confirm I am happy to accept the award and continue
 
-    = render "form"
+    .citation class='govuk-!-display-none'
+      = render "form"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -33,6 +33,8 @@
             = link_to "Sign out", destroy_user_session_path, method: :delete, class: 'govuk-header__link'
         - elsif current_group_leader.present?
           li.govuk-header__navigation-item
+            = link_to "Dashboard", group_leader_root_path, class: 'govuk-header__link'
+          li.govuk-header__navigation-item
             = link_to "Sign out", destroy_group_leader_session_path, method: :delete, class: 'govuk-header__link'
 
 - content_for :inside_header do
@@ -48,7 +50,7 @@
 - content_for :content do
   .govuk-width-container class="govuk-!-margin-top-4 govuk-!-margin-bottom-1"
     = render "shared/offline_message"
-  
+
   #wrapper.guide.smart-answer.answer class="#{yield :page_wrapper_class}"
     #QAE class="#{'admin-mode' if admin_in_read_only_mode?} #{'layout-dev' if Rails.env.development?}"
       .govuk-width-container

--- a/spec/features/group_leaders/citation_spec.rb
+++ b/spec/features/group_leaders/citation_spec.rb
@@ -12,20 +12,20 @@ describe "Citation process" do
     login_group_leader(group_leader)
   end
 
-  it 'disables the submit button until the group leader confiorms acceptance' do
+  it 'hides the citation until the group leader confiorms acceptance' do
     click_link "Confirm group name and citation"
 
     expect(page).to have_content("Do you accept the Queen's Award for Voluntary Service on behalf of your group?")
-
   end
 
-  # it "allows group_leader to confirm citation" do
-  #   click_link "Confirm group name and citation"
+  it "allows group_leader to confirm citation" do
+    click_link "Confirm group name and citation"
+    check 'accept-award'
+    
+    expect(page).to have_content("Group name and citation confirmation")
 
-  #   expect(page).to have_content("Group name and citation confirmation")
+    click_button "Submit"
 
-  #   click_button "Submit"
-
-  #   expect(page).to have_selector(".notice", text: "Citation successfully updated!")
-  # end
+    expect(page).to have_selector(".notice", text: "Citation successfully updated!")
+  end
 end

--- a/spec/features/group_leaders/citation_spec.rb
+++ b/spec/features/group_leaders/citation_spec.rb
@@ -12,13 +12,20 @@ describe "Citation process" do
     login_group_leader(group_leader)
   end
 
-  it "allows group_leader to confirm citation" do
+  it 'disables the submit button until the group leader confiorms acceptance' do
     click_link "Confirm group name and citation"
 
-    expect(page).to have_content("Group name and citation confirmation")
+    expect(page).to have_content("Do you accept the Queen's Award for Voluntary Service on behalf of your group?")
 
-    click_button "Submit"
-
-    expect(page).to have_selector(".notice", text: "Citation successfully updated!")
   end
+
+  # it "allows group_leader to confirm citation" do
+  #   click_link "Confirm group name and citation"
+
+  #   expect(page).to have_content("Group name and citation confirmation")
+
+  #   click_button "Submit"
+
+  #   expect(page).to have_selector(".notice", text: "Citation successfully updated!")
+  # end
 end


### PR DESCRIPTION
- adds dashboard nav link
- adds a confirmation checkbox to the citation page

![Screenshot 2021-08-17 at 17 28 35](https://user-images.githubusercontent.com/65811538/129766538-e8606925-944c-4d68-97b1-b25b5fad3754.png)

- once checkbox is selected the question is hidden and the form is displayed

![Screenshot 2021-08-17 at 17 28 51](https://user-images.githubusercontent.com/65811538/129766608-72a7467b-1625-48eb-86ed-b3e561a038e2.png)

Content to be confirmed and persistence state for acceptance to be added at a later date