### PR TITLE
admin assessors UI tweaks

### DIFF
--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -51,3 +51,7 @@ $todo-black: #333;
 .govuk-select {
   padding-right: 20px
 }
+
+.govuk-notification-banner__heading {
+  max-width: 700px
+}

--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -1,11 +1,11 @@
 = simple_form_for [:admin, resource], as: :assessor, url: resource.persisted? ? admin_assessor_path(resource) : admin_assessors_path, html: { class: 'qae-form' } do |f|
   = f.input :first_name,
             input_html: { class: 'small' },
-            label: 'First name'
+            label_html: { class: 'govuk-label--s' }
 
   = f.input :last_name,
             input_html: { class: 'small' },
-            label: 'Last name'
+            label_html: { class: 'govuk-label--s' }
 
   = f.input :sub_group,
             input_html: { class: 'govuk-select' },
@@ -14,16 +14,17 @@
             label_html: { class: 'govuk-label--s' }
 
   = f.input :email,
-            input_html: { class: 'large' },
-            label: 'Email'
+            input_html: { class: 'medium' },
+            label_html: { class: 'govuk-label--s' }
 
   - if f.object.persisted?
     .question-group#password-change-panel
       #password-control-group
         .input-group
           = f.input :password,
-                    input_html: { class: 'small' },
-                    label: 'Password'
+                    input_html: { class: 'medium' },
+                    label: 'New password',
+                    label_html: { class: 'govuk-label--s' }
           span#password-result-span.input-group-addon
             i#password-result.glyphicon.glyphicon-ok
         .clear
@@ -43,8 +44,9 @@
       #password-confirmation-control-group
         .input-group
           = f.input :password_confirmation,
-                    input_html: { class: 'small' },
-                    label: 'Retype password'
+                    input_html: { class: 'medium' },
+                    label: 'Confirm new password',
+                    label_html: { class: 'govuk-label--s' }
           span#password-confirmation-result-span.input-group-addon
             i#password-confirmation-result.glyphicon.glyphicon-ok
         .clear

--- a/app/views/admin/assessors/edit.html.slim
+++ b/app/views/admin/assessors/edit.html.slim
@@ -1,0 +1,4 @@
+h1.govuk-heading-xl
+  | Edit national assessor
+
+= render 'form', resource: @resource

--- a/app/views/admin/assessors/new.html.slim
+++ b/app/views/admin/assessors/new.html.slim
@@ -1,0 +1,4 @@
+h1.govuk-heading-xl
+  | Add national assessor
+
+= render 'form', resource: @resource


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1DKkfFLgnpT3MYHUWoZu86tUblJ6h815jh2dMSehQxZA/edit#gid=0


Admin editing/adding assessors
#19 per above spreadsheet
- changes header copy to match designs
- makes label style consistent
- updates password labels as per design

#20 per above spreadsheet
- matches input widths to design

![Screenshot 2021-08-17 at 18 34 25](https://user-images.githubusercontent.com/65811538/129776932-9367e941-ea86-4d86-bf7d-12ebfe1cc15c.png)

Bulk assign assessors
#26 per above spreadsheet
- widens the notice to display message on one line

![Screenshot 2021-08-17 at 18 53 26](https://user-images.githubusercontent.com/65811538/129777095-434660fd-250d-4c2a-9df8-8126e7ffcfd5.png)

