### PR TITLE
layout bug fixes

### DIFF
--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -285,8 +285,8 @@ select.read-only {
     background-position: center;
 
     position: absolute;
-    left: -20px;
-    top: 10px;
+    left: -22px;
+    top: 6px;
   }
 
   &:focus {
@@ -315,7 +315,7 @@ select.read-only {
 }
 
 .download-pdf-link {
-  margin: 0.25em 0 0;
+  margin: 0.25em 1em 0;
   font-size: 1.25em;
 
   svg {

--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -286,7 +286,7 @@ select.read-only {
 
     position: absolute;
     left: -22px;
-    top: 6px;
+    top: 10px;
   }
 
   &:focus {
@@ -315,10 +315,18 @@ select.read-only {
 }
 
 .download-pdf-link {
-  margin: 0.25em 1em 0;
+  margin: 0 1em 0;
   font-size: 1.25em;
 
   svg {
     margin-right: 0.5em;
+  }
+}
+
+.inline-link {
+  &:before {
+    display: inline-block;
+    position: relative;
+    top: 2px;
   }
 }

--- a/app/views/content_only/_pdf_link.html.slim
+++ b/app/views/content_only/_pdf_link.html.slim
@@ -1,14 +1,13 @@
 h3.govuk-heading-m Blank nomination form in PDF format
 p.govuk-body
   - if QAE.hide_pdf_links?
-    strong 
+    strong
       | All nominations must be completed online
     | , but if you find it useful to have it in PDF format for planning purposes, downloadable PDF of the form will be available from 17th of May.
   - else
-    strong 
+    strong
       | All nominations must be completed online
     | , but you may find it useful to have a blank copy of it in PDF format for planning purposes.
 
 =< link_to users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true), class: "download-pdf-link govuk-link" do
-  = render "download_icon"
   | Download blank PDF form

--- a/app/views/content_only/_pdf_link.html.slim
+++ b/app/views/content_only/_pdf_link.html.slim
@@ -9,5 +9,5 @@ p.govuk-body
       | All nominations must be completed online
     | , but you may find it useful to have a blank copy of it in PDF format for planning purposes.
 
-=< link_to users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true), class: "download-pdf-link govuk-link" do
+=< link_to users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true), class: "download-pdf-link govuk-link inline-link" do
   | Download blank PDF form

--- a/app/views/content_only/_steps_progress_bar.html.slim
+++ b/app/views/content_only/_steps_progress_bar.html.slim
@@ -18,7 +18,7 @@
           - @form.current_steps(@form_answer, current_form_user).each_with_index do |step, index|
             = step_link_to step.short_title.html_safe, result_form_award_eligibility_url(form_id: @form_answer.id, anchor: step.title.html_safe.parameterize), index: index + 3, active: 2, index_name: "#{step_letters[index]}.", cant_access_future: false, class: 'govuk-link'
     li.divider
-    li.sidebar-helpline
+    li.sidebar-helpline.govuk-body
       ' Need help? Call us on
       br
       ' 0207 271 6206

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -19,7 +19,7 @@ article.group role="article"
         span.govuk-warning-text__assistive
           | Warning
       	' The entry period for the #{ AwardYear.current.year } awards has now closed.
-	br
+	    br
         ' Award winners will be announced on
         =< application_deadline_for_year(AwardYear.current, :buckingham_palace_attendees_details, "with_year")
         ' .


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1DKkfFLgnpT3MYHUWoZu86tUblJ6h815jh2dMSehQxZA/edit#gid=0
spreadsheet #25 

- fixes the layout of the contact details on the useful information page which had been overlapping
- tweaks to the download icon for the blank pdf download

![Screenshot 2021-08-18 at 08 33 49](https://user-images.githubusercontent.com/65811538/129859560-c0bc8ec8-7298-42c8-b7ae-3b59cf299e7f.png)

- tweaks to the download icon position

![Screenshot 2021-08-18 at 08 33 59](https://user-images.githubusercontent.com/65811538/129859427-80f93015-24a5-4732-9361-95c7648fc32b.png)

spreadsheet #29
- fixes styling of closed season award winner message

![Screenshot 2021-08-18 at 09 02 09](https://user-images.githubusercontent.com/65811538/129861261-bf308f20-e248-4054-9989-c0400d53dc80.png)






