### PR TITLE
making tables more accessible

### DIFF
--- a/app/assets/stylesheets/admin/tables.scss
+++ b/app/assets/stylesheets/admin/tables.scss
@@ -1,0 +1,7 @@
+[role="region"][aria-labelledby][tabindex] {
+  overflow: auto;
+}
+
+[role="region"][aria-labelledby][tabindex]:focus {
+  outline: .1em solid rgba(0,0,0,.1);
+}

--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -24,6 +24,7 @@ $button-colour: #00823b;
 @import "admin/page-dashboard";
 @import "admin/page-eligibility";
 @import "admin/date-time-picker";
+@import "admin/tables";
 @import "./micromodal";
 
 // HIGHLIGHT PLACEHOLDER BITS

--- a/app/assets/stylesheets/frontend/tables.scss
+++ b/app/assets/stylesheets/frontend/tables.scss
@@ -26,3 +26,11 @@
     }
   }
 }
+
+[role="region"][aria-label][tabindex] {
+  overflow: auto;
+}
+
+[role="region"][aria-label][tabindex]:focus {
+  outline: .1em solid rgba(0,0,0,.1);
+}

--- a/app/views/admin/admins/_list.html.slim
+++ b/app/views/admin/admins/_list.html.slim
@@ -1,37 +1,38 @@
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-  tbody.govuk-table__body
-    - if AdminDecorator.decorate_collection(resources).none?
+ div role="region" aria-label="list of admin users" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
       tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.p-empty No admins found.
-          br
-    - else
-      - AdminDecorator.decorate_collection(resources).each do |admin|
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+    tbody.govuk-table__body
+      - if AdminDecorator.decorate_collection(resources).none?
         tr.govuk-table__row
-          th.govuk-table__header scope="row"
-            = link_to admin.full_name, edit_admin_admin_path(admin), class: 'link-edit-user'
-          td.govuk-table__cell = mail_to admin.email, admin.email, {class: "ellipsis"}
-          td.govuk-table__cell
-            small.text-muted
-              span.visible-lg
-                = admin.formatted_last_sign_in_at_long
-              span.hidden-lg
-                = admin.formatted_last_sign_in_at_short
-          td.govuk-table__cell
-            - if admin.confirmed_at.present?
+          td.text-center colspan=100
+            br
+            p.p-empty No admins found.
+            br
+      - else
+        - AdminDecorator.decorate_collection(resources).each do |admin|
+          tr.govuk-table__row
+            th.govuk-table__header scope="row"
+              = link_to admin.full_name, edit_admin_admin_path(admin), class: 'link-edit-user'
+            td.govuk-table__cell = mail_to admin.email, admin.email, {class: "ellipsis"}
+            td.govuk-table__cell
               small.text-muted
-                = l admin.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
+                span.visible-lg
+                  = admin.formatted_last_sign_in_at_long
+                span.hidden-lg
+                  = admin.formatted_last_sign_in_at_short
+            td.govuk-table__cell
+              - if admin.confirmed_at.present?
+                small.text-muted
+                  = l admin.confirmed_at, format: :date_at_time
+              - else
+                small.text-danger
+                  ' Not confirmed

--- a/app/views/admin/assessors/_list.html.slim
+++ b/app/views/admin/assessors/_list.html.slim
@@ -1,56 +1,57 @@
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.sortable.govuk-table__header scope='col'
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope='col'
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope='col'
-        = sort_link f, 'National assessor sub-group', @search, :sub_group
-      th.sortable.govuk-table__header scope='col'
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope='col'
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Locked on", @search, :locked_at
-      th
-  tbody.govuk-table__body
-    - if AssessorDecorator.decorate_collection(resources).none?
+div role="region" aria-label="list of national assessors" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
       tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.p-empty No assessors found.
-          br
-    - else
-      - AssessorDecorator.decorate_collection(resources).each do |assessor|
+        th.sortable.govuk-table__header scope='col'
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope='col'
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope='col'
+          = sort_link f, 'National assessor sub-group', @search, :sub_group
+        th.sortable.govuk-table__header scope='col'
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope='col'
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Locked on", @search, :locked_at
+        th
+    tbody.govuk-table__body
+      - if AssessorDecorator.decorate_collection(resources).none?
         tr.govuk-table__row
-          th.govuk-table__header scope="row"
-            = link_to assessor.full_name, edit_admin_assessor_path(assessor), class: 'link-edit-user'
-          td.govuk-table__cell = mail_to assessor.email, assessor.email, {class: "ellipsis"}
-          td.govuk-table__cell
-            = assessor.sub_group.text
-          td.govuk-table__cell
-            small.text-muted
-              - if assessor.last_sign_in_at.present?
-                span.visible-lg
-                  = assessor.formatted_last_sign_in_at_long
-                span class="govuk-!-display-none"
-                  = assessor.formatted_last_sign_in_at_short
+          td.text-center colspan=100
+            br
+            p.p-empty No assessors found.
+            br
+      - else
+        - AssessorDecorator.decorate_collection(resources).each do |assessor|
+          tr.govuk-table__row
+            th.govuk-table__header scope="row"
+              = link_to assessor.full_name, edit_admin_assessor_path(assessor), class: 'link-edit-user'
+            td.govuk-table__cell = mail_to assessor.email, assessor.email, {class: "ellipsis"}
+            td.govuk-table__cell
+              = assessor.sub_group.text
+            td.govuk-table__cell
+              small.text-muted
+                - if assessor.last_sign_in_at.present?
+                  span.visible-lg
+                    = assessor.formatted_last_sign_in_at_long
+                  span class="govuk-!-display-none"
+                    = assessor.formatted_last_sign_in_at_short
+                - else
+                  | Never signed in
+            td.govuk-table__cell
+              - if assessor.confirmed_at.present?
+                small.text-muted
+                  = l assessor.confirmed_at, format: :date_at_time
               - else
-                | Never signed in
-          td.govuk-table__cell
-            - if assessor.confirmed_at.present?
-              small.text-muted
-                = l assessor.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
-          td.govuk-table__cell
-            - if assessor.locked_at.present?
-              small.text-muted
-                = l assessor.locked_at, format: :date_at_time
-            - else
-              small.text-muted
-                ' Not locked
-          td.govuk-table__cell
-            = link_to "Edit user", edit_admin_assessor_path(assessor)
+                small.text-danger
+                  ' Not confirmed
+            td.govuk-table__cell
+              - if assessor.locked_at.present?
+                small.text-muted
+                  = l assessor.locked_at, format: :date_at_time
+              - else
+                small.text-muted
+                  ' Not locked
+            td.govuk-table__cell
+              = link_to "Edit user", edit_admin_assessor_path(assessor)

--- a/app/views/admin/audit_logs/index.html.slim
+++ b/app/views/admin/audit_logs/index.html.slim
@@ -1,36 +1,37 @@
 .dashboard
   h1.govuk-heading-xl
     | Data Export Log
-  table.govuk-table
-    colgroup
-      col width="100"
-      col width="100"
-      col width="400"
-    thead.govuk-table__head
-      tr.govuk-table__row
-        th.sortable.govuk-table__header scope="col"
-          ' Date
-        th.sortable.govuk-table__header scope="col"
-          ' User
-        th.sortable.govuk-table__header scope="col"
-          ' Data Exported
-    tbody.govuk-table__body
-      - if @audit_logs.none?
+  div role="region" aria-label="list of audit logs" tabindex="0"
+    table.govuk-table
+      colgroup
+        col width="100"
+        col width="100"
+        col width="400"
+      thead.govuk-table__head
         tr.govuk-table__row
-          td.text-center.govuk-table__cell colspan=100
-            br
-            p.p-empty No audit logs.
-            br
-      - else
-        - @audit_logs.each do |audit_log|
+          th.sortable.govuk-table__header scope="col"
+            ' Date
+          th.sortable.govuk-table__header scope="col"
+            ' User
+          th.sortable.govuk-table__header scope="col"
+            ' Data Exported
+      tbody.govuk-table__body
+        - if @audit_logs.none?
           tr.govuk-table__row
-            td.govuk-table__cell
-              = audit_log.created_at.strftime("%d/%m/%Y %-l:%M%P")
-            td.govuk-table__cell
-              = audit_log.subject.email
-            td.govuk-table__cell
-              - if audit_log.action_type != "download_form_answer"
-                = t("audit_logs.action_types.#{audit_log.action_type.gsub(/-/, '_')}")
-              - else
-                = link_to t("audit_logs.action_types.#{audit_log.action_type}"), admin_form_answers_path(audit_log.auditable)
+            td.text-center.govuk-table__cell colspan=100
+              br
+              p.p-empty No audit logs.
+              br
+        - else
+          - @audit_logs.each do |audit_log|
+            tr.govuk-table__row
+              td.govuk-table__cell
+                = audit_log.created_at.strftime("%d/%m/%Y %-l:%M%P")
+              td.govuk-table__cell
+                = audit_log.subject.email
+              td.govuk-table__cell
+                - if audit_log.action_type != "download_form_answer"
+                  = t("audit_logs.action_types.#{audit_log.action_type.gsub(/-/, '_')}")
+                - else
+                  = link_to t("audit_logs.action_types.#{audit_log.action_type}"), admin_form_answers_path(audit_log.auditable)
   = paginate @audit_logs

--- a/app/views/admin/dashboard/_applications_report.html.slim
+++ b/app/views/admin/dashboard/_applications_report.html.slim
@@ -1,12 +1,13 @@
 .dashboard-table__wrapper.dashboard-report
-  table.dashboard-table.govuk-table class="govuk-!-font-size-14"
-    caption.govuk-table__caption.govuk-table__caption--m
-      = title
-      a.govuk-button.btn--load.update-report href=url
-        | Load data
-      button.govuk-button.btn--loading.updating-data.hidden
-        | Updating data
-    = render "admin/dashboard/totals_#{kind}/table_head"
+  div role="region" aria-label="nomination report" tabindex="0"
+    table.dashboard-table.govuk-table class="govuk-!-font-size-14"
+      caption.govuk-table__caption.govuk-table__caption--m
+        = title
+        a.govuk-button.btn--load.update-report href=url
+          | Load data
+        button.govuk-button.btn--loading.updating-data.hidden
+          | Updating data
+      = render "admin/dashboard/totals_#{kind}/table_head"
 
-    tbody.govuk-table__body
-      = render "admin/dashboard/totals_#{kind}/table_body"
+      tbody.govuk-table__body
+        = render "admin/dashboard/totals_#{kind}/table_body"

--- a/app/views/admin/dashboard/live_data/_applications_in_progress.html.slim
+++ b/app/views/admin/dashboard/live_data/_applications_in_progress.html.slim
@@ -1,37 +1,38 @@
-table.dashboard-table.govuk-table class="govuk-!-font-size-14"
-  caption.govuk-table__caption.govuk-table__caption--m
-   | Nominations in progress
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.border-right.bold.govuk-table__header width="250"
-        | Award
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | Not eligible
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | 0%
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | 1 - 24%
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | 25 - 49%
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | 50 - 74%
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | 75-99%
-      th.bold.govuk-table__header.govuk-table__header--numeric width="100"
-        | Total in progress
-  tbody.govuk-table__body
-    - completions = @statistics.applications_completions
-    tr.govuk-table__row
-      th.bold.govuk-table__header Award
-      - ar_size = completions["awards"].size
-      - completions["awards"].each_with_index do |count, index|
-        - if index + 1 == ar_size
-          td.bold.govuk-table__cell.govuk-table__cell--numeric = count
-        - else
-          td.govuk-table__cell.govuk-table__cell--numeric = count
+div role="region" aria-label="nominations in progress" tabindex="0"
+  table.dashboard-table.govuk-table class="govuk-!-font-size-14"
+    caption.govuk-table__caption.govuk-table__caption--m
+    | Nominations in progress
+    thead.govuk-table__head
+      tr.govuk-table__row
+        th.border-right.bold.govuk-table__header width="250"
+          | Award
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | Not eligible
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | 0%
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | 1 - 24%
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | 25 - 49%
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | 50 - 74%
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | 75-99%
+        th.bold.govuk-table__header.govuk-table__header--numeric width="100"
+          | Total in progress
+    tbody.govuk-table__body
+      - completions = @statistics.applications_completions
+      tr.govuk-table__row
+        th.bold.govuk-table__header Award
+        - ar_size = completions["awards"].size
+        - completions["awards"].each_with_index do |count, index|
+          - if index + 1 == ar_size
+            td.bold.govuk-table__cell.govuk-table__cell--numeric = count
+          - else
+            td.govuk-table__cell.govuk-table__cell--numeric = count
 
-    tr.govuk-table__row
-      th.uppercase.bold.govuk-table__header Total
-      - completions["total"].each_with_index do |count, index|
-        td.bold.govuk-table__cell.govuk-table__cell--numeric
-          = count
+      tr.govuk-table__row
+        th.uppercase.bold.govuk-table__header Total
+        - completions["total"].each_with_index do |count, index|
+          td.bold.govuk-table__cell.govuk-table__cell--numeric
+            = count

--- a/app/views/admin/dashboard/live_data/_submitted_applications.html.slim
+++ b/app/views/admin/dashboard/live_data/_submitted_applications.html.slim
@@ -1,23 +1,24 @@
-table.dashboard-table.govuk-table class="govuk-!-font-size-14"
-  caption.govuk-table__caption.govuk-table__caption--m
-   | nominations
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.bold.border-right.govuk-table__header width="250" Award
-      th.bold.govuk-table__header.govuk-table__header--numeric width="125" Last 24h
-      th.bold.govuk-table__header.govuk-table__header--numeric width="125" Last 7 days
-      th.bold.govuk-table__header.govuk-table__header--numeric width="125" Total
-  tbody.govuk-table__body
-    - submissions = @statistics.applications_submissions
-    tr.govuk-table__row
-      th.bold.govuk-table__header Award
-      - ar_size = submissions["awards"].size
-      - submissions["awards"].each_with_index do |count, index|
-        - if index + 1 == ar_size
-          td.bold.govuk-table__header.govuk-table__header--numeric =count
-        - else
-          td.govuk-table__header.govuk-table__header--numeric = count
-    tr.govuk-table__row
-      th.bold.govuk-table__header Total
-      - submissions["total"].each do |count|
-        td.bold.govuk-table__header.govuk-table__header--numeric = count
+div role="region" aria-label="submitted nominations" tabindex="0"
+  table.dashboard-table.govuk-table class="govuk-!-font-size-14"
+    caption.govuk-table__caption.govuk-table__caption--m
+    | nominations
+    thead.govuk-table__head
+      tr.govuk-table__row
+        th.bold.border-right.govuk-table__header width="250" Award
+        th.bold.govuk-table__header.govuk-table__header--numeric width="125" Last 24h
+        th.bold.govuk-table__header.govuk-table__header--numeric width="125" Last 7 days
+        th.bold.govuk-table__header.govuk-table__header--numeric width="125" Total
+    tbody.govuk-table__body
+      - submissions = @statistics.applications_submissions
+      tr.govuk-table__row
+        th.bold.govuk-table__header Award
+        - ar_size = submissions["awards"].size
+        - submissions["awards"].each_with_index do |count, index|
+          - if index + 1 == ar_size
+            td.bold.govuk-table__header.govuk-table__header--numeric =count
+          - else
+            td.govuk-table__header.govuk-table__header--numeric = count
+      tr.govuk-table__row
+        th.bold.govuk-table__header Total
+        - submissions["total"].each do |count|
+          td.bold.govuk-table__header.govuk-table__header--numeric = count

--- a/app/views/admin/dashboard/live_data/_summary.html.slim
+++ b/app/views/admin/dashboard/live_data/_summary.html.slim
@@ -1,14 +1,15 @@
-table.dashboard-table.govuk-table class="govuk-!-font-size-14"
-  caption.govuk-table__caption.govuk-table__caption--m Summary
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.govuk-table__header.bold.border-right scope='col' width="250" Parameter
-      th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Last 24h
-      th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Last 7 days
-      th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Total
-  tbody.govuk-table__body
-    - applications = @statistics.applications_table.each do |_, app|
+div role="region" aria-label="summary" tabindex="0"
+  table.dashboard-table.govuk-table class="govuk-!-font-size-14"
+    caption.govuk-table__caption.govuk-table__caption--m Summary
+    thead.govuk-table__head
       tr.govuk-table__row
-        th.bold.govuk-table__header = app[:name]
-        - app[:counters].each_with_index do |count, i|
-          td.govuk-table__cell.govuk-table__cell--numeric class=(i == 2 ? "bold" : "") = count
+        th.govuk-table__header.bold.border-right scope='col' width="250" Parameter
+        th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Last 24h
+        th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Last 7 days
+        th.govuk-table__header.govuk-table__header--numeric.bold scope='col' width="125" Total
+    tbody.govuk-table__body
+      - applications = @statistics.applications_table.each do |_, app|
+        tr.govuk-table__row
+          th.bold.govuk-table__header = app[:name]
+          - app[:counters].each_with_index do |count, i|
+            td.govuk-table__cell.govuk-table__cell--numeric class=(i == 2 ? "bold" : "") = count

--- a/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
@@ -1,29 +1,30 @@
 .dashboard-table__wrapper.dashboard-report
-  table.govuk-table.dashboard-table class="govuk-!-font-size-14"
-    caption.govuk-table__caption.govuk-table__caption--m
-      | New account registrations
-      a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_day")
-        | Load data
-      button.govuk-button.btn.btn-primary.btn--loading.updating-data.hidden
-        | Updating data
+  div role="region" aria-label="new account registrations" tabindex="0"
+    table.govuk-table.dashboard-table class="govuk-!-font-size-14"
+      caption.govuk-table__caption.govuk-table__caption--m
+        | New account registrations
+        a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_day")
+          | Load data
+        button.govuk-button.btn.btn-primary.btn--loading.updating-data.hidden
+          | Updating data
 
-    thead.govuk-table__head
-      tr.govuk-table__row
-        th.bold.border-right.govuk-table__header scope="row" width="150"
-          | Year
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 6 days before
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 5 days before
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 4 days before
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 3 days before
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 2 days before
-        th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
-          | Up to end of 1 day before
-        th.bold.govuk-table__header.govuk-table__header--numeric width="140"
-          | Totals on deadline
-    tbody.govuk-table__body
-      = render "admin/dashboard/totals_by_week/users_table_body"
+      thead.govuk-table__head
+        tr.govuk-table__row
+          th.bold.border-right.govuk-table__header scope="row" width="150"
+            | Year
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 6 days before
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 5 days before
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 4 days before
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 3 days before
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 2 days before
+          th.bold.border-right.govuk-table__header.govuk-table__header--numeric width="140"
+            | Up to end of 1 day before
+          th.bold.govuk-table__header.govuk-table__header--numeric width="140"
+            | Totals on deadline
+      tbody.govuk-table__body
+        = render "admin/dashboard/totals_by_week/users_table_body"

--- a/app/views/admin/dashboard/totals_by_month/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_month/_registrations.html.slim
@@ -1,27 +1,28 @@
 .dashboard-table__wrapper.dashboard-report
-  table.govuk-table.dashboard-table class="govuk-!-font-size-14"
-    caption.govuk-table__caption.govuk-table__caption--m
-      | New account registrations
-      a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_month")
-        | Load data
-      button.btn.btn-primary.btn--loading.updating-data.hidden.govuk-button
-        | Updating data
+  div role="region" aria-label="new account registrations" tabindex="0"
+    table.govuk-table.dashboard-table class="govuk-!-font-size-14"
+      caption.govuk-table__caption.govuk-table__caption--m
+        | New account registrations
+        a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_month")
+          | Load data
+        button.btn.btn-primary.btn--loading.updating-data.hidden.govuk-button
+          | Updating data
 
-    thead.govuk-table__head
-      tr.govuk-table__row
-        th.bold.border-right.govuk-table__header width="150"
-          | Year
-        th.bold.border-right.govuk-table__header width="140"
-          | By end of April
-        th.bold.border-right.govuk-table__header width="140"
-          | By end of May
-        th.bold.border-right.govuk-table__header width="140"
-          | By end of June
-        th.bold.border-right.govuk-table__header width="140"
-          | By end of July
-        th.bold.border-right .govuk-table__headerwidth="140"
-          | By end of August
-        th.bold.govuk-table__header width="140"
-          | Totals on deadline
-    tbody.govuk-table__body
-      = render "admin/dashboard/totals_by_month/users_table_body"
+      thead.govuk-table__head
+        tr.govuk-table__row
+          th.bold.border-right.govuk-table__header width="150"
+            | Year
+          th.bold.border-right.govuk-table__header width="140"
+            | By end of April
+          th.bold.border-right.govuk-table__header width="140"
+            | By end of May
+          th.bold.border-right.govuk-table__header width="140"
+            | By end of June
+          th.bold.border-right.govuk-table__header width="140"
+            | By end of July
+          th.bold.border-right .govuk-table__headerwidth="140"
+            | By end of August
+          th.bold.govuk-table__header width="140"
+            | Totals on deadline
+      tbody.govuk-table__body
+        = render "admin/dashboard/totals_by_month/users_table_body"

--- a/app/views/admin/dashboard/totals_by_week/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_week/_registrations.html.slim
@@ -1,29 +1,30 @@
 .dashboard-table__wrapper.dashboard-report
-  table.dashboard-table.govuk-table class="govuk-!-font-size-14"
-    caption
-      | New account registrations
-      a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_week")
-        | Load data
-      button.btn.btn-primary.btn--loading.updating-data.hidden
-        | Updating data
+  div role="region" aria-label="new account registrations" tabindex="0"
+    table.dashboard-table.govuk-table class="govuk-!-font-size-14"
+      caption
+        | New account registrations
+        a.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_week")
+          | Load data
+        button.btn.btn-primary.btn--loading.updating-data.hidden
+          | Updating data
 
-    thead.govuk-table__head
-      tr.govuk-table__row
-        th.govuk-table__header.bold.border-right scope="col" width="150"
-          | Year
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 6 weeks before
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 5 weeks before
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 4 weeks before
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 3 weeks before
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 2 weeks before
-        th.govuk-table__header.bold.border-right scope="col" width="140"
-          | Up to end of 1 week before
-        th.govuk-table__header.bold scope="col" width="140"
-          | Totals on deadline
-    tbody
-      = render "admin/dashboard/totals_by_week/users_table_body"
+      thead.govuk-table__head
+        tr.govuk-table__row
+          th.govuk-table__header.bold.border-right scope="col" width="150"
+            | Year
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 6 weeks before
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 5 weeks before
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 4 weeks before
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 3 weeks before
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 2 weeks before
+          th.govuk-table__header.bold.border-right scope="col" width="140"
+            | Up to end of 1 week before
+          th.govuk-table__header.bold scope="col" width="140"
+            | Totals on deadline
+      tbody
+        = render "admin/dashboard/totals_by_week/users_table_body"

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -1,29 +1,30 @@
-table.govuk-table.applications-table class="govuk-!-margin-top-7 govuk-!-margin-bottom-9"
-  - if @search.query?
-    caption.govuk-table__caption.govuk-table__caption--m
-      => "Search results for '#{@search.query}'"
-      = link_to "(Clear search)", admin_form_answers_path, class: "govuk-link govuk-!-margin-left-3"
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.govuk-table__header scope="col"
-        span.if-no-js-hide
-          = check_box_tag :check_all
-      th.sortable.govuk-table__header scope="col" width="450"
-        = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
-      th.govuk-table__header scope="col" width="250"
-        | Status
-      th.govuk-table__header scope="col" width="100"
-        | Postcode
-      th.govuk-table__header scope="col" width="250"
-        | Lord Lieutenancy as per form
-      th.govuk-table__header scope="col" width="250"
-        | Lord Lieutenancy assigned
-      th.govuk-table__header scope="col" width="200"
-        | Type of group
-      th.sortable.govuk-table__header scope="col" width="130"
-        = sort_link f, "National assessor sub-group", @search, :sub_group, disabled: @search.query?
-      th.sortable.govuk-table__header scope="col" width="130"
-        = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
-      th.govuk-table__header scope="col" View
-  tbody.govuk-table__body
-    = render("admin/form_answers/list_components/table_body")
+div role="region" aria-label="nominations list" tabindex="0"
+  table.govuk-table.applications-table class="govuk-!-margin-top-7 govuk-!-margin-bottom-9"
+    - if @search.query?
+      caption.govuk-table__caption.govuk-table__caption--m
+        => "Search results for '#{@search.query}'"
+        = link_to "(Clear search)", admin_form_answers_path, class: "govuk-link govuk-!-margin-left-3"
+    thead.govuk-table__head
+      tr.govuk-table__row
+        th.govuk-table__header scope="col"
+          span.if-no-js-hide
+            = check_box_tag :check_all
+        th.sortable.govuk-table__header scope="col" width="450"
+          = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
+        th.govuk-table__header scope="col" width="250"
+          | Status
+        th.govuk-table__header scope="col" width="100"
+          | Postcode
+        th.govuk-table__header scope="col" width="250"
+          | Lord Lieutenancy as per form
+        th.govuk-table__header scope="col" width="250"
+          | Lord Lieutenancy assigned
+        th.govuk-table__header scope="col" width="200"
+          | Type of group
+        th.sortable.govuk-table__header scope="col" width="130"
+          = sort_link f, "National assessor sub-group", @search, :sub_group, disabled: @search.query?
+        th.sortable.govuk-table__header scope="col" width="130"
+          = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
+        th.govuk-table__header scope="col" View
+    tbody.govuk-table__body
+      = render("admin/form_answers/list_components/table_body")

--- a/app/views/admin/group_leaders/_list.html.slim
+++ b/app/views/admin/group_leaders/_list.html.slim
@@ -1,52 +1,53 @@
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-tabke__row
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Locked on", @search, :locked_at
-      th
-  tbody.govuk-table__body
-    - if resources.none?
-      tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.govuk-body.p-empty No group leaders found.
-          br
-    - else
-      - GroupLeaderDecorator.decorate_collection(resources).each do |group_leader|
+div role="region" aria-label="list of group leaders" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
+      tr.govuk-tabke__row
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Locked on", @search, :locked_at
+        th
+    tbody.govuk-table__body
+      - if resources.none?
         tr.govuk-table__row
-          th.govuk-table__header scope="row"
-            = link_to group_leader.full_name, edit_admin_group_leader_path(group_leader), class: 'link-edit-user'
-          td.govuk-table__cell = mail_to group_leader.email, group_leader.email, {class: "ellipsis"}
-          td.govuk-table__cell
-            small.text-muted
-              - if group_leader.last_sign_in_at.present?
-                span.visible-lg
-                  = group_leader.formatted_last_sign_in_at_long
-                span.hidden-lg
-                  = group_leader.formatted_last_sign_in_at_short
+          td.text-center colspan=100
+            br
+            p.govuk-body.p-empty No group leaders found.
+            br
+      - else
+        - GroupLeaderDecorator.decorate_collection(resources).each do |group_leader|
+          tr.govuk-table__row
+            th.govuk-table__header scope="row"
+              = link_to group_leader.full_name, edit_admin_group_leader_path(group_leader), class: 'link-edit-user'
+            td.govuk-table__cell = mail_to group_leader.email, group_leader.email, {class: "ellipsis"}
+            td.govuk-table__cell
+              small.text-muted
+                - if group_leader.last_sign_in_at.present?
+                  span.visible-lg
+                    = group_leader.formatted_last_sign_in_at_long
+                  span.hidden-lg
+                    = group_leader.formatted_last_sign_in_at_short
+                - else
+                  | Never signed in
+            td.govuk-table__cell
+              - if group_leader.confirmed_at.present?
+                small.text-muted
+                  = l group_leader.confirmed_at, format: :date_at_time
               - else
-                | Never signed in
-          td.govuk-table__cell
-            - if group_leader.confirmed_at.present?
-              small.text-muted
-                = l group_leader.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
-          td.govuk-table__cell
-            - if group_leader.locked_at.present?
-              small.text-muted
-                = l group_leader.locked_at, format: :date_at_time
-            - else
-              small.text-muted
-                ' Not locked
-          td.govuk-table__cell
-            = link_to "Edit user", edit_admin_group_leader_path(group_leader)
+                small.text-danger
+                  ' Not confirmed
+            td.govuk-table__cell
+              - if group_leader.locked_at.present?
+                small.text-muted
+                  = l group_leader.locked_at, format: :date_at_time
+              - else
+                small.text-muted
+                  ' Not locked
+            td.govuk-table__cell
+              = link_to "Edit user", edit_admin_group_leader_path(group_leader)

--- a/app/views/admin/lieutenants/_list.html.slim
+++ b/app/views/admin/lieutenants/_list.html.slim
@@ -1,60 +1,61 @@
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-tabke__row
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Lord Lieutenancy office', @search, :ceremonial_county_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Type', @search, :role
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Locked on", @search, :locked_at
-      th
-  tbody.govuk-table__body
-    - if resources.none?
-      tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.govuk-body.p-empty No lieutenants found.
-          br
-    - else
-      - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
+div role="region" aria-label="list of lord lieutenancy office users" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
+      tr.govuk-tabke__row
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Lord Lieutenancy office', @search, :ceremonial_county_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Type', @search, :role
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Locked on", @search, :locked_at
+        th
+    tbody.govuk-table__body
+      - if resources.none?
         tr.govuk-table__row
-          th.govuk-table__header scope="row"
-            = link_to lieutenant.full_name, edit_admin_lieutenant_path(lieutenant), class: 'link-edit-user'
-          td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
-          td.govuk-table__cell
-            = lieutenant.ceremonial_county.name
-          td.govuk-table__cell
-            = lieutenant.role_text
-          td.govuk-table__cell
-            small.text-muted
-              - if lieutenant.last_sign_in_at.present?
-                span.visible-lg
-                  = lieutenant.formatted_last_sign_in_at_long
-                span.hidden-lg
-                  = lieutenant.formatted_last_sign_in_at_short
+          td.text-center colspan=100
+            br
+            p.govuk-body.p-empty No Lord Lieutenancy office users found.
+            br
+      - else
+        - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
+          tr.govuk-table__row
+            th.govuk-table__header scope="row"
+              = link_to lieutenant.full_name, edit_admin_lieutenant_path(lieutenant), class: 'link-edit-user'
+            td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
+            td.govuk-table__cell
+              = lieutenant.ceremonial_county.name
+            td.govuk-table__cell
+              = lieutenant.role_text
+            td.govuk-table__cell
+              small.text-muted
+                - if lieutenant.last_sign_in_at.present?
+                  span.visible-lg
+                    = lieutenant.formatted_last_sign_in_at_long
+                  span.hidden-lg
+                    = lieutenant.formatted_last_sign_in_at_short
+                - else
+                  | Never signed in
+            td.govuk-table__cell
+              - if lieutenant.confirmed_at.present?
+                small.text-muted
+                  = l lieutenant.confirmed_at, format: :date_at_time
               - else
-                | Never signed in
-          td.govuk-table__cell
-            - if lieutenant.confirmed_at.present?
-              small.text-muted
-                = l lieutenant.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
-          td.govuk-table__cell
-            - if lieutenant.locked_at.present?
-              small.text-muted
-                = l lieutenant.locked_at, format: :date_at_time
-            - else
-              small.text-muted
-                ' Not locked
-          td.govuk-table__cell
-            = link_to "Edit user", edit_admin_lieutenant_path(lieutenant)
+                small.text-danger
+                  ' Not confirmed
+            td.govuk-table__cell
+              - if lieutenant.locked_at.present?
+                small.text-muted
+                  = l lieutenant.locked_at, format: :date_at_time
+              - else
+                small.text-muted
+                  ' Not locked
+            td.govuk-table__cell
+              = link_to "Edit user", edit_admin_lieutenant_path(lieutenant)

--- a/app/views/admin/users/_list.html.slim
+++ b/app/views/admin/users/_list.html.slim
@@ -1,49 +1,49 @@
-
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Company', @search, :company_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Locked?", @search, :locked_at
-  tbody.govuk-table__body
-    - if UserDecorator.decorate_collection(resources).none?
+div role="region" aria-label="list of nominators" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
       tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.p-empty No users found.
-          br
-    - else
-      - UserDecorator.decorate_collection(resources).each do |user|
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Company', @search, :company_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Locked?", @search, :locked_at
+    tbody.govuk-table__body
+      - if UserDecorator.decorate_collection(resources).none?
         tr.govuk-table__row
-          th.govuk-table__header scope="row"
-            = link_to edit_admin_user_path(user), class: "link-edit-user" do
-              span.ellipsis
-                = user.full_name
-          td.govuk-table__cell = mail_to user.email, user.email, {class: "ellipsis"}
-          td.govuk-table__cell = user.company
-          td.govuk-table__cell
-            small.text-muted
-              span.visible-lg
-                = user.formatted_last_sign_in_at_long
-              span class="govuk-!-display-none"
-                = user.formatted_last_sign_in_at_short
-          td.govuk-table__cell
-            - if user.confirmed_at.present?
+          td.text-center colspan=100
+            br
+            p.p-empty No users found.
+            br
+      - else
+        - UserDecorator.decorate_collection(resources).each do |user|
+          tr.govuk-table__row
+            th.govuk-table__header scope="row"
+              = link_to edit_admin_user_path(user), class: "link-edit-user" do
+                span.ellipsis
+                  = user.full_name
+            td.govuk-table__cell = mail_to user.email, user.email, {class: "ellipsis"}
+            td.govuk-table__cell = user.company
+            td.govuk-table__cell
               small.text-muted
-                = l user.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
-          td.govuk-table__cell
-            - if user.locked_at.present?
-              small.text-muted
-                = l user.locked_at, format: :date_at_time
+                span.visible-lg
+                  = user.formatted_last_sign_in_at_long
+                span class="govuk-!-display-none"
+                  = user.formatted_last_sign_in_at_short
+            td.govuk-table__cell
+              - if user.confirmed_at.present?
+                small.text-muted
+                  = l user.confirmed_at, format: :date_at_time
+              - else
+                small.text-danger
+                  ' Not confirmed
+            td.govuk-table__cell
+              - if user.locked_at.present?
+                small.text-muted
+                  = l user.locked_at, format: :date_at_time

--- a/app/views/admin/users_feedbacks/show.html.slim
+++ b/app/views/admin/users_feedbacks/show.html.slim
@@ -1,39 +1,40 @@
 .dashboard
   h1.govuk-heading-xl
     | Feedback
-  table.govuk-table
-    colgroup
-      col width="100"
-      col width="100"
-      col width="400"
-    thead.govuk-table__head
-      tr.govuk-table__row
-        th.sortable.govuk-table__header scope="col"
-          ' Date
-        th.sortable.govuk-table__header scope="col"
-          ' Rating
-        th.sortable.govuk-table__header scope="col"
-          ' Feedback
-    tbody.govuk-table__body
-      - if @feedbacks.none?
+  div role="region" aria-label="feedback list" tabindex="0"
+    table.govuk-table
+      colgroup
+        col width="100"
+        col width="100"
+        col width="400"
+      thead.govuk-table__head
         tr.govuk-table__row
-          td.text-center.govuk-table__cell colspan=100
-            br
-            p.p-empty No feedback received.
-            br
-      - else
-        - @feedbacks.each do |feedback|
+          th.sortable.govuk-table__header scope="col"
+            ' Date
+          th.sortable.govuk-table__header scope="col"
+            ' Rating
+          th.sortable.govuk-table__header scope="col"
+            ' Feedback
+      tbody.govuk-table__body
+        - if @feedbacks.none?
           tr.govuk-table__row
-            td.govuk-table__cell
-              = feedback.created_at.strftime("%d/%m/%Y %-l:%M%P")
-            td.govuk-table__cell
-              span.feedback-stars alt=feedback.rating.text title=feedback.rating.text
-                - feedback.rating.value.times do
-                  span.glyphicon.glyphicon-star
-                - (5 - feedback.rating.value).times do
-                  span.glyphicon.glyphicon-star-empty
-            td.govuk-table__cell
-              .feedback-description
-                = feedback.comment
+            td.text-center.govuk-table__cell colspan=100
+              br
+              p.p-empty No feedback received.
+              br
+        - else
+          - @feedbacks.each do |feedback|
+            tr.govuk-table__row
+              td.govuk-table__cell
+                = feedback.created_at.strftime("%d/%m/%Y %-l:%M%P")
+              td.govuk-table__cell
+                span.feedback-stars alt=feedback.rating.text title=feedback.rating.text
+                  - feedback.rating.value.times do
+                    span.glyphicon.glyphicon-star
+                  - (5 - feedback.rating.value).times do
+                    span.glyphicon.glyphicon-star-empty
+              td.govuk-table__cell
+                .feedback-description
+                  = feedback.comment
 
   = paginate @feedbacks

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -19,29 +19,29 @@ h1.govuk-heading-xl
   - # this bulk assignment form breaks the flow of the sorting + filtering forms, as the form needs to do a update somewhere else than the forms above and below. So you'll see some duplication of fields. Commented on them so no one removes them by accident
   = render("assessor/form_answers/bulk_assignment")
 
-
-  table.applications-table.govuk-table
-    - if @search.query?
-      caption.govuk-table__caption.govuk-table__caption--m
-        = "Search results for '#{@search.query}'"
-        = link_to "(Clear search)", assessor_form_answers_path, class: "govuk-link"
-    thead.govuk-table__head
-      tr.govuk-table__row
-        - if current_subject.categories_as_lead.include?(category_picker.current_award_type)
-          th.govuk-table__header scope='col'
-            span.if-no-js-hide
-              = check_box_tag :check_all
-        th.sortable.govuk-table__header scope='col' width="250"
-          = sort_link f, "Company", @search, :company_or_nominee_name, disabled: @search.query?
-        th.govuk-table__header scope='col' width="250"
-          | Status
-        th.sortable.govuk-table__header scope='col' width="70"
-          = sort_link f, "SIC Code", @search, :sic_code, disabled: @search.query?
-        th.sortable.govuk-table__header scope='col' width="130"
-          = sort_link f, "Applied before", @search, :applied_before, disabled: @search.query?
-        = render("assessor/form_answers/assessor_header", f: f)
-        th.sortable.govuk-table__header scope='col' width="130"
-          = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
-      = render(partial: "assessor/form_answers/list_body")
+  div role="region" aria-label="nominations list" tabindex="0"
+    table.applications-table.govuk-table
+      - if @search.query?
+        caption.govuk-table__caption.govuk-table__caption--m
+          = "Search results for '#{@search.query}'"
+          = link_to "(Clear search)", assessor_form_answers_path, class: "govuk-link"
+      thead.govuk-table__head
+        tr.govuk-table__row
+          - if current_subject.categories_as_lead.include?(category_picker.current_award_type)
+            th.govuk-table__header scope='col'
+              span.if-no-js-hide
+                = check_box_tag :check_all
+          th.sortable.govuk-table__header scope='col' width="250"
+            = sort_link f, "Company", @search, :company_or_nominee_name, disabled: @search.query?
+          th.govuk-table__header scope='col' width="250"
+            | Status
+          th.sortable.govuk-table__header scope='col' width="70"
+            = sort_link f, "SIC Code", @search, :sic_code, disabled: @search.query?
+          th.sortable.govuk-table__header scope='col' width="130"
+            = sort_link f, "Applied before", @search, :applied_before, disabled: @search.query?
+          = render("assessor/form_answers/assessor_header", f: f)
+          th.sortable.govuk-table__header scope='col' width="130"
+            = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
+        = render(partial: "assessor/form_answers/list_body")
 
   = paginate @form_answers

--- a/app/views/content_only/cookies.html.slim
+++ b/app/views/content_only/cookies.html.slim
@@ -36,7 +36,7 @@ h1.govuk-heading-xl
       ul.govuk-list.govuk-list--bullet
         li the pages you visit on GOV.UK
         li how long you spend on each GOV.UK page
-        li how you got to the site 
+        li how you got to the site
         li what you click on while you're visiting the site
 
       p.govuk-body
@@ -47,41 +47,42 @@ h1.govuk-heading-xl
 
       p.govuk-body Google Analytics sets the following cookies:
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell _ga
-            td.govuk-table__cell This helps us count how many people visit GOV.UK by tracking if you have visited before
-            td.govuk-table__cell 2 years
-          tr.govuk-table__row
-            td.govuk-table__cell _utma
-            td.govuk-table__cell Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to GOV.UK or to a certain page
-            td.govuk-table__cell 2 years
-          tr.govuk-table__row
-            td.govuk-table__cell _utmb
-            td.govuk-table__cell This works with.govuk-table__header _utmc to calculate the average length.govuk-table__header of time you spend on GOV.UK
-            td.govuk-table__cell 30 minutes
-          tr.govuk-table__row
-            td.govuk-table__cell _utmc
-            td.govuk-table__cell This works with.govuk-table__header _utmb to calculate when you close your browser
-            td.govuk-table__cell when you close your browser
-          tr.govuk-table__row
-            td.govuk-table__cell _utmz
-            td.govuk-table__cell This tells us how you reached GOV.UK (like from another website or a search engine)
-            td.govuk-table__cell 6 months
-          tr.govuk-table__row
-            td.govuk-table__cell analytics_nextpage_call
-            td.govuk-table__cell This lets us know the next page you visit on GOV.UK, so we can make journeys better
-            td.govuk-table__cell when you close your browser
-          tr.govuk-table__row
-            td.govuk-table__cell GDS_successEvents and GDS_analyticsTokens
-            td.govuk-table__cell These help us identify how you use GOV.UK so we can make the site better
-            td.govuk-table__cell 4 months
+      div role="region" aria-label="google analytics cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell _ga
+              td.govuk-table__cell This helps us count how many people visit GOV.UK by tracking if you have visited before
+              td.govuk-table__cell 2 years
+            tr.govuk-table__row
+              td.govuk-table__cell _utma
+              td.govuk-table__cell Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to GOV.UK or to a certain page
+              td.govuk-table__cell 2 years
+            tr.govuk-table__row
+              td.govuk-table__cell _utmb
+              td.govuk-table__cell This works with.govuk-table__header _utmc to calculate the average length.govuk-table__header of time you spend on GOV.UK
+              td.govuk-table__cell 30 minutes
+            tr.govuk-table__row
+              td.govuk-table__cell _utmc
+              td.govuk-table__cell This works with.govuk-table__header _utmb to calculate when you close your browser
+              td.govuk-table__cell when you close your browser
+            tr.govuk-table__row
+              td.govuk-table__cell _utmz
+              td.govuk-table__cell This tells us how you reached GOV.UK (like from another website or a search engine)
+              td.govuk-table__cell 6 months
+            tr.govuk-table__row
+              td.govuk-table__cell analytics_nextpage_call
+              td.govuk-table__cell This lets us know the next page you visit on GOV.UK, so we can make journeys better
+              td.govuk-table__cell when you close your browser
+            tr.govuk-table__row
+              td.govuk-table__cell GDS_successEvents and GDS_analyticsTokens
+              td.govuk-table__cell These help us identify how you use GOV.UK so we can make the site better
+              td.govuk-table__cell 4 months
 
       h3.govuk-heading-m User ID
       p.govuk-body
@@ -95,21 +96,22 @@ h1.govuk-heading-xl
           span.hidden-content
             p.hint
               | If you opt out, weʼll set a QAE cookie to remember your decision.
-            table.govuk-table
-              thead.govuk-table__head
-                tr.govuk-table__row
-                  th.govuk-table__header Name
-                  th.govuk-table__header Purpose
-                  th.govuk-table__header Expires
-              tbody.govuk-table__body
-                tr.govuk-table__row
-                  td.govuk-table__cell gaoptout (superseded)
-                  td.govuk-table__cell This allows us to make sure Google Analytics cookies are turned off when you visit our service in future.
-                  td.govuk-table__cell 10 years
-                tr.govuk-table__row
-                  td.govuk-table__cell gaconsent
-                  td.govuk-table__cell Stores explicit consent from user whether or not they allow Google Analytics to track them.
-                  td.govuk-table__cell 10 years
+            div role="region" aria-label="cookie consent cookies" tabindex="0"
+              table.govuk-table
+                thead.govuk-table__head
+                  tr.govuk-table__row
+                    th.govuk-table__header Name
+                    th.govuk-table__header Purpose
+                    th.govuk-table__header Expires
+                tbody.govuk-table__body
+                  tr.govuk-table__row
+                    td.govuk-table__cell gaoptout (superseded)
+                    td.govuk-table__cell This allows us to make sure Google Analytics cookies are turned off when you visit our service in future.
+                    td.govuk-table__cell 10 years
+                  tr.govuk-table__row
+                    td.govuk-table__cell gaconsent
+                    td.govuk-table__cell Stores explicit consent from user whether or not they allow Google Analytics to track them.
+                    td.govuk-table__cell 10 years
 
             label.hint
               => check_box_tag "ga-optout-input", "1"
@@ -122,53 +124,56 @@ h1.govuk-heading-xl
 
       p.govuk-body You may see a pop-up welcome message when you first visit GOV.UK. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell seen_cookie_message
-            td.govuk-table__cell Saves a message to let us know that you have seen our cookie message
-            td.govuk-table__cell 1 month
+      div role="region" aria-label="seen cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell seen_cookie_message
+              td.govuk-table__cell Saves a message to let us know that you have seen our cookie message
+              td.govuk-table__cell 1 month
 
       h3.govuk-heading-m Your progress when applying for a licence
 
       p.govuk-body When you apply for a licence using the 'apply for a licence' service, we'll set a cookie to remember your progress through the forms. These cookies don't store your personal data and are deleted once you've completed the transaction.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell licensing_session
-            td.govuk-table__cell Set to remember information you have entered into a form when applying for a licence
-            td.govuk-table__cell When you close your browser
+      div role="region" aria-label="licensing session cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell licensing_session
+              td.govuk-table__cell Set to remember information you have entered into a form when applying for a licence
+              td.govuk-table__cell When you close your browser
 
       h3.govuk-heading-m YouTube videos
 
       p.govuk-body We use YouTube to provide videos on some pages of the site. YouTube sets cookies when you visit one of these pages.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell _use_hitbox
-            td.govuk-table__cell This is a randomly generated number that identifies your browser
-            td.govuk-table__cell When you close your browser
-          tr.govuk-table__row
-            td.govuk-table__cell VISITOR_INFO1_LIVE
-            td.govuk-table__cell Lets Youtube count the views of embedded Youtube videos
-            td.govuk-table__cell 9 months
+      div role="region" aria-label="youtube cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell _use_hitbox
+              td.govuk-table__cell This is a randomly generated number that identifies your browser
+              td.govuk-table__cell When you close your browser
+            tr.govuk-table__row
+              td.govuk-table__cell VISITOR_INFO1_LIVE
+              td.govuk-table__cell Lets Youtube count the views of embedded Youtube videos
+              td.govuk-table__cell 9 months
 
       h3.govuk-heading-m Directgov-branded government services
 
@@ -184,87 +189,91 @@ h1.govuk-heading-xl
 
       p.govuk-body We'll also save a cookie that lets us know you don't want to see the prompt if you dismiss it.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell govuk_not_first_visit
-            td.govuk-table__cell Stops us prompting you to upgrade an out-of-date browser until after your first visit
-            td.govuk-table__cell 28 days
-          tr.govuk-table__row
-            td.govuk-table__cell govuk_browser_upgrade_dismissed
-            td.govuk-table__cell Saves a message to let us know you've seen and dismissed the browser upgrade prompt
-            td.govuk-table__cell 28 days
+      div role="region" aria-label="browser upgrade cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell govuk_not_first_visit
+              td.govuk-table__cell Stops us prompting you to upgrade an out-of-date browser until after your first visit
+              td.govuk-table__cell 28 days
+            tr.govuk-table__row
+              td.govuk-table__cell govuk_browser_upgrade_dismissed
+              td.govuk-table__cell Saves a message to let us know you've seen and dismissed the browser upgrade prompt
+              td.govuk-table__cell 28 days
 
       h3.govuk-heading-m Our user satisfaction survey
 
       p.govuk-body We select some users to take part in a user-satisfaction survey. If you choose to take part, or dismiss the survey, we'll save a cookie that lets us know that you've seen the message so that we don't show it to you again.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell govuk_takenUserSatisfactionSurvey
-            td.govuk-table__cell Saves a message to remember if you've taken the survey or dismissed it
-            td.govuk-table__cell 4 months
+      div role="region" aria-label="user satisfaction survey cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell govuk_takenUserSatisfactionSurvey
+              td.govuk-table__cell Saves a message to remember if you've taken the survey or dismissed it
+              td.govuk-table__cell 4 months
 
       p.govuk-body
         ' We use
         = link_to "SurveyMonkey", "http://www.surveymonkey.com/", rel: "external", class: 'govuk-link'
         '  to collect responses to the survey. If you take part, SurveyMonkey will save extra cookies to your computer to track your progress through it.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell mbox
-            td.govuk-table__cell This is used to keep your progress through the survey
-            td.govuk-table__cell 30 minutes
+      div role="region" aria-label="survey monkey cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell mbox
+              td.govuk-table__cell This is used to keep your progress through the survey
+              td.govuk-table__cell 30 minutes
 
-          tr.govuk-table__row
-            td.govuk-table__cell SSOE
-            td.govuk-table__cell This is used for testing different content and features on the survey website to help make it better
-            td.govuk-table__cell When you close your browser
+            tr.govuk-table__row
+              td.govuk-table__cell SSOE
+              td.govuk-table__cell This is used for testing different content and features on the survey website to help make it better
+              td.govuk-table__cell When you close your browser
 
-          tr.govuk-table__row
-            td.govuk-table__cell TS5159a2 and TSd0b041
-            td.govuk-table__cell These are used to manage survey traffic by sending your computer to a specific server
-            td.govuk-table__cell When you close your browser
+            tr.govuk-table__row
+              td.govuk-table__cell TS5159a2 and TSd0b041
+              td.govuk-table__cell These are used to manage survey traffic by sending your computer to a specific server
+              td.govuk-table__cell When you close your browser
 
-          tr.govuk-table__row
-            td.govuk-table__cell ep201
-            td.govuk-table__cell This is used to help us identify how you use the survey
-            td.govuk-table__cell 30 minutes
+            tr.govuk-table__row
+              td.govuk-table__cell ep201
+              td.govuk-table__cell This is used to help us identify how you use the survey
+              td.govuk-table__cell 30 minutes
 
-          tr.govuk-table__row
-            td.govuk-table__cell ep202
-            td.govuk-table__cell This works with.govuk-table__header ep201 to help us identify how you use the survey
-            td.govuk-table__cell 1 year
+            tr.govuk-table__row
+              td.govuk-table__cell ep202
+              td.govuk-table__cell This works with.govuk-table__header ep201 to help us identify how you use the survey
+              td.govuk-table__cell 1 year
 
       h3.govuk-heading-m Multivariate testing
 
       p.govuk-body We sometimes test different versions of pages with.govuk-table__header different users to see which work better. We'll save a cookie so that you consistently see the same version when browsing GOV.UK.
 
-      table.govuk-table
-        thead.govuk-table__head
-          tr.govuk-table__row
-            th.govuk-table__header Name
-            th.govuk-table__header Purpose
-            th.govuk-table__header Expires
-        tbody.govuk-table__body
-          tr.govuk-table__row
-            td.govuk-table__cell multivariatetest_cohort_topics_menu_text
-            td.govuk-table__cell Remember which version of the page you were shown
-            td.govuk-table__cell 1 month
+      div role="region" aria-label="multivariate testing cookies" tabindex="0"
+        table.govuk-table
+          thead.govuk-table__head
+            tr.govuk-table__row
+              th.govuk-table__header Name
+              th.govuk-table__header Purpose
+              th.govuk-table__header Expires
+          tbody.govuk-table__body
+            tr.govuk-table__row
+              td.govuk-table__cell multivariatetest_cohort_topics_menu_text
+              td.govuk-table__cell Remember which version of the page you were shown
+              td.govuk-table__cell 1 month

--- a/app/views/lieutenant/form_answers/index.html.slim
+++ b/app/views/lieutenant/form_answers/index.html.slim
@@ -23,22 +23,23 @@ h1.govuk-heading-xl
     = link_to "Remove filters", lieutenant_form_answers_path, class: "govuk-button govuk-button--secondary"
 
   .applications-table-wrapper
-    table.govuk-table.applications-table
-      - if @search.query?
-        caption.govuk-table__caption.govuk-table__caption--m
-          => "Search results for '#{@search.query}'"
-          = link_to "(Clear search)", lieutenant_form_answers_path, class: "govuk-link govuk-!-margin-left-3"
-      thead
-        tr
-          th.sortable.govuk-table__header scope="col" width="250"
-            = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
-          th.sortable.govuk-table__header scope="col" width="120"
-            = sort_link f, "Reference", @search, :urn, disabled: @search.query?
-          th.govuk-table__header scope="col" width="250"
-            | Status
-          = render("assessor/form_answers/assessor_header", f: f)
-          th.sortable.govuk-table__header scope="col" width="130"
-            = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
-        = render(partial: "list_body")
+    div role="region" aria-label="nominations list" tabindex="0"
+      table.govuk-table.applications-table
+        - if @search.query?
+          caption.govuk-table__caption.govuk-table__caption--m
+            => "Search results for '#{@search.query}'"
+            = link_to "(Clear search)", lieutenant_form_answers_path, class: "govuk-link govuk-!-margin-left-3"
+        thead
+          tr
+            th.sortable.govuk-table__header scope="col" width="250"
+              = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
+            th.sortable.govuk-table__header scope="col" width="120"
+              = sort_link f, "Reference", @search, :urn, disabled: @search.query?
+            th.govuk-table__header scope="col" width="250"
+              | Status
+            = render("assessor/form_answers/assessor_header", f: f)
+            th.sortable.govuk-table__header scope="col" width="130"
+              = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
+          = render(partial: "list_body")
 
   = paginate @form_answers

--- a/app/views/lieutenant/lieutenants/_list.html.slim
+++ b/app/views/lieutenant/lieutenants/_list.html.slim
@@ -1,42 +1,43 @@
-table.govuk-table
-  thead.govuk-table__head
-    tr.govuk-table__row
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Name', @search, :full_name
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Email', @search, :email
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Type', @search, :role
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, 'Signed in on', @search, :last_sign_in_at
-      th.sortable.govuk-table__header scope="col"
-        = sort_link f, "Confirmed on", @search, :confirmed_at
-      th.govuk-table__header
-  tbody.govuk-table__body
-    - if resources.none?
+div role="region" aria-label="list of lord lieutenancy office users" tabindex="0"
+  table.govuk-table
+    thead.govuk-table__head
       tr.govuk-table__row
-        td.text-center colspan=100
-          br
-          p.p-empty No lieutenants found.
-          br
-    - else
-      - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Name', @search, :full_name
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Email', @search, :email
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Type', @search, :role
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, 'Signed in on', @search, :last_sign_in_at
+        th.sortable.govuk-table__header scope="col"
+          = sort_link f, "Confirmed on", @search, :confirmed_at
+        th.govuk-table__header
+    tbody.govuk-table__body
+      - if resources.none?
         tr.govuk-table__row
-          td.govuk-table__cell = lieutenant.full_name
-          td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
-          td.govuk-table__cell = lieutenant.role.humanize
-          td.govuk-table__cell
-            small.text-muted
-              span.visible-lg
-                = lieutenant.formatted_last_sign_in_at_long
-              span class="govuk-!-display-none"
-                = lieutenant.formatted_last_sign_in_at_short
-          td.govuk-table__cell
-            - if lieutenant.confirmed_at.present?
+          td.text-center colspan=100
+            br
+            p.p-empty No lieutenants found.
+            br
+      - else
+        - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
+          tr.govuk-table__row
+            td.govuk-table__cell = lieutenant.full_name
+            td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis"}
+            td.govuk-table__cell = lieutenant.role.humanize
+            td.govuk-table__cell
               small.text-muted
-                = l lieutenant.confirmed_at, format: :date_at_time
-            - else
-              small.text-danger
-                ' Not confirmed
-          td.govuk-table__cell
-            = link_to "Edit user", edit_lieutenant_lieutenant_path(lieutenant), class: "link-edit-user", id: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }"
+                span.visible-lg
+                  = lieutenant.formatted_last_sign_in_at_long
+                span class="govuk-!-display-none"
+                  = lieutenant.formatted_last_sign_in_at_short
+            td.govuk-table__cell
+              - if lieutenant.confirmed_at.present?
+                small.text-muted
+                  = l lieutenant.confirmed_at, format: :date_at_time
+              - else
+                small.text-danger
+                  ' Not confirmed
+            td.govuk-table__cell
+              = link_to "Edit user", edit_lieutenant_lieutenant_path(lieutenant), class: "link-edit-user", id: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3803,5 +3803,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210810175339'),
 ('20210816072005'),
 ('20210817084427');
-
-


### PR DESCRIPTION
This PR increases accessibility for all tables across the application.

HTML changes
- tables are wrapped in a div with a region, and aria-label and a tabindex. The tabindex="0" satisfies WCAG SC 2.1.1 Keyboard (A), which allows a keyboard-only user to tab to the container (giving it focus) and scroll it using the keyboard.

CSS changes
- The overflow: auto satisfies WCAG SC 1.4.10 Reflow (AA) by preventing the entire page from having two axes of scrolling (big table, small viewport).

- The outline covers WCAG SC 2.4.7 Focus Visible (AA), but to be safe on WCAG SC 1.4.11 Non-text Contrast (AA), use an outline color with a 3:1 contrast ratio. Using outline ensures it will be visible in Windows High Contrast Mode.