### PR TITLE
bug fixes

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -422,8 +422,8 @@ window.FormValidation =
   validateSupportLetters: (question) ->
     lettersReceived = $(".js-support-letter-received").size()
     if lettersReceived < 2
-      @logThis(question, "validateSupportLetters", "You need to request or upload at least 2 letters of support")
-      @appendMessage(question, "You need to request or upload at least 2 letters of support")
+      @logThis(question, "validateSupportLetters", "Upload at least two letters of support")
+      @appendMessage(question, "Upload at least two letters of support")
       @addErrorClass(question)
 
   validateSelectionLimit: (question) ->

--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -316,7 +316,6 @@ select.read-only {
 
 .download-pdf-link {
   margin: 0 1em 0;
-  font-size: 1.25em;
 
   svg {
     margin-right: 0.5em;

--- a/app/models/eligibility.rb
+++ b/app/models/eligibility.rb
@@ -82,7 +82,7 @@ class Eligibility < ApplicationRecord
   end
 
   def eligible?
-    questions.all? do |question|
+    questions.map.all? do |question|
       answer = answers && answers[question.to_s]
       answer_valid?(question, answer)
     end

--- a/app/models/eligibility.rb
+++ b/app/models/eligibility.rb
@@ -82,7 +82,7 @@ class Eligibility < ApplicationRecord
   end
 
   def eligible?
-    questions.map.all? do |question|
+    questions.all? do |question|
       answer = answers && answers[question.to_s]
       answer_valid?(question, answer)
     end

--- a/app/models/eligibility/basic.rb
+++ b/app/models/eligibility/basic.rb
@@ -37,19 +37,6 @@ class Eligibility::Basic < Eligibility
            label: "Are you a current Queen's Award holder in any category?",
            accept: :not_nil
 
-  def eligible?
-    current_step_index = questions.index(current_step) || questions.size - 1
-    previous_questions = questions[0..current_step_index]
-
-    answers.present? && answers.all? do |question, answer|
-      if previous_questions.include?(question.to_sym)
-        answer_valid?(question, answer)
-      else
-        true
-      end
-    end
-  end
-
   def save_as_eligible!
     self.national_organisation = false
     self.based_in_uk = true

--- a/app/views/content_only/_pdf_link.html.slim
+++ b/app/views/content_only/_pdf_link.html.slim
@@ -9,5 +9,6 @@ p.govuk-body
       | All nominations must be completed online
     | , but you may find it useful to have a blank copy of it in PDF format for planning purposes.
 
-=< link_to users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true), class: "download-pdf-link govuk-link inline-link" do
-  | Download blank PDF form
+p.govuk-body
+  =< link_to users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true), class: "download-pdf-link govuk-link inline-link" do
+    | Download blank nomination form (PDF)

--- a/app/views/form_award_eligibilities/show.html.slim
+++ b/app/views/form_award_eligibilities/show.html.slim
@@ -10,14 +10,14 @@ h1.govuk-heading-xl Queen's Award for Voluntary Service Nomination
               .govuk-form-group.current-question.qae-form#current-question
                 fieldset.govuk-fieldset class="question-#{step.to_s.gsub!(/_/, '-')}"
                   = render "form_award_eligibilities/basic_questions/#{step.to_s}", f: f, question: step.to_s
-                  
+
                 .next-question
                   = f.submit "Continue", class: "govuk-button"
           - else
             .previous-answers
               - if @form_answer.eligible?
                 .eligibility-passed
-                  p.govuk-body-l You are eligible to begin your nomination for a #{@form_answer.award_type_full_name.split.map(&:capitalize)*' '} Award.
+                  p.govuk-body-l You are eligible to begin your nomination.
                   p.govuk-body-l Before you start your nomination, please check your eligibility answers are correct.
 
                 - if (!step || step.to_s == "wicked_finish")
@@ -32,10 +32,6 @@ h1.govuk-heading-xl Queen's Award for Voluntary Service Nomination
                     strong not eligible
                     '  for this award. Please see your answers below for the reason. If you think you made a mistake in the eligibility questionnaire, you can change your answer.
 
-                  p.govuk-body-l
-                    ' Also, you might be eligible for awards in other categories. Go to the
-                    = link_to "nominations page", dashboard_path
-                    | to nominate.
         = render "previous_answers"
 
         - if (!step || step.to_s == "wicked_finish")

--- a/app/views/qae_form/show.html.slim
+++ b/app/views/qae_form/show.html.slim
@@ -19,7 +19,7 @@ form.qae-form.award-form data-autosave-url=save_form_url(@form_answer) action=sa
           h2.govuk-error-summary__title#letters-of-support-error-title There was a problem submitting the form
           .govuk-error-summary__body
             p.govuk-body
-              ' You need to request or upload at least 2 letters of support.
+              ' Upload at least two letters of support.
             p.govuk-body
               = link_to "Add more letters of support", form_form_answer_supporters_path(@form_answer), class: 'govuk-link'
 

--- a/app/views/shared/_application_awards_status.html.slim
+++ b/app/views/shared/_application_awards_status.html.slim
@@ -16,5 +16,5 @@
 /* link:      Download PDF
 /* action:    Download PDF of your application
 
-.pull-left
-  = link_to "Start a new nomination", apply_qavs_award_path, "aria-label" => "New nomination", class: "govuk-button"
+.govuk-button-group
+  = link_to "Start a new nomination", apply_qavs_award_path, "aria-label" => "New nomination", class: "govuk-button govuk-button--start"

--- a/spec/models/eligibility/basic_spec.rb
+++ b/spec/models/eligibility/basic_spec.rb
@@ -31,16 +31,17 @@ RSpec.describe Eligibility::Basic, type: :model do
       eligibility.national_organisation = false
       eligibility.based_in_uk = true
 
-      expect(eligibility).to be_eligible
+      expect(eligibility).to_not be_eligible
     end
 
     it 'is eligible when all questions are answered correctly' do
-      eligibility.national_organisation = false
       eligibility.based_in_uk = true
       eligibility.are_majority_volunteers = true
       eligibility.benefits_animals_only = false
+      eligibility.national_organisation = false
       eligibility.has_at_least_three_people = true
       eligibility.years_operating = 3
+      eligibility.current_holder = "no"
 
       expect(eligibility).to be_eligible
     end
@@ -56,7 +57,7 @@ RSpec.describe Eligibility::Basic, type: :model do
   end
 
   describe "#save_as_eligible" do
-    let(:eligibility) { Eligibility::Basic.new(account: account) }
+    let(:eligibility) { FactoryBot.create(:basic_eligibility) }
 
     it "saves and marks eligibilty as eligible" do
       eligibility.save_as_eligible!


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1gHPAcUI7i3dlo2i57Z_II7tUrZ_wVImA683OqEWuJKQ/edit#gid=0

Eligibility fix
- spreadsheet#11 - basic eligibility was passing while the form was in progress. This allowed users to bypass eligibility by starting a survey, quitting and then returning which sent users to the nomination form. This PR removes the eligible? method on basic eligibility - instead relying on the inherited method which returns false if some questions are unanswered
- removes copy text relating other other awards on the eligibility messages

Other fixes
- spreadsheet#7 - uses govuk start button style for new nominations
- spreadsheet#23 - styles download link to consistent size with rest of page and updates label
- spreadsheet#24 - updates download pdf link label
- spreadsheet#37 - updated letters of support error message
