### PR TITLE
local assessment form amendments

### DIFF
--- a/app/forms/award_years/v2022/qavs/qavs_step4.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step4.rb
@@ -61,7 +61,7 @@ class AwardYears::V2022::QAEForms
           required
           text -> do
             %(
-              I have read and understood the contents of the Privacy Notice
+              I have read and understood the contents of the <a href="https://qavs.dcms.gov.uk/privacy-policy/">Privacy Notice
             )
           end
         end

--- a/app/forms/award_years/v2022/qavs/qavs_step4.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step4.rb
@@ -61,9 +61,12 @@ class AwardYears::V2022::QAEForms
           required
           text -> do
             %(
-              I have read and understood the contents of the <a href="https://qavs.dcms.gov.uk/privacy-policy/">Privacy Notice
+              I have read and understood the contents of the <a href="https://qavs.dcms.gov.uk/privacy-policy/">Privacy Notice</a>
             )
           end
+          pdf_context %(
+            I have read and understood the contents of the Pivacy Notice
+          )
         end
 
         confirm :group_leader_aware, "" do

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -203,12 +203,13 @@ class AwardYears::V2022::QAEForms
           sub_ref "E 4.8"
           yes_no
           conditional :nomination_local_assessment_form_beneficiaries_based_abroad, "yes"
-
+          required
         end
 
         textarea :nomination_local_assessment_form_how_benefits_local_and_abroad, "In what ways does the group's existence benefit the local community as well as people elsewhere?" do
           sub_ref "E 4.9"
           conditional :nomination_local_assessment_form_beneficiaries_based_abroad, "yes"
+          required
         end
 
         header :local_assessments_volunteers_header, "Role and status of volunteers" do
@@ -392,17 +393,30 @@ class AwardYears::V2022::QAEForms
 
         text :nomination_local_assessment_worthy_of_honour_name, "Please give the name of the person you are recommending" do
           sub_ref "E 8.4"
-          style "medium"
           conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"
+          required
+          style "medium"
         end
 
         textarea :nomination_local_assessment_worthy_of_honur_reasons, "Please explain in one sentence why they might merit this" do
           sub_ref "E 8.5"
+          conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"
           context %(
             <p class='govuk-hint'>Please note, the QAVS team will pass this information onto the DCMS Honours team. They might get in touch with you in due course to ask for further details.</p>
           )
+          required
           words_max 50
+        end
+
+        assessor_details :assessor_nominating_member_worthy_of_honour, "Assessor recommending an individual for a national Honour details" do
+          sub_ref "E 8.6"
           conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"
+          required
+          sub_fields([
+            { full_name: "Full name" },
+            { email: "Email address" },
+            { phone: "Phone number (optional)", ignore_validation: true }
+          ])
         end
 
         textarea :nomination_local_assessment_form_citation_full, "Lord-Lieutenant evaluation summary" do

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -16,6 +16,10 @@ class AwardYears::V2022::QAEForms
         assessor_details :assessor_details, 'Assessor details' do
           sub_ref "E 1.1"
           required
+          sub_fields([
+            { primary_assessor_name: "Full name of the first assessor" },
+            { secondary_assessor_name: "Full name of the second assessor (if applicable)", ignore_validation: true }
+          ])
         end
 
         text :nomination_local_assessment_form_nominee_name, "Group name" do
@@ -410,8 +414,8 @@ class AwardYears::V2022::QAEForms
 
         assessor_details :assessor_nominating_member_worthy_of_honour, "Assessor recommending an individual for a national Honour details" do
           sub_ref "E 8.6"
-          conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"
           required
+          conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"
           sub_fields([
             { full_name: "Full name" },
             { email: "Email address" },

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -10,14 +10,7 @@ class AwardYears::V2022::QAEForms
         end
 
         assessor_details :assessor_details, 'Assessor details' do
-          sub_ref "E1.1"
-
-          sub_fields([
-            {full_name: "Full name"},
-            {email: "Email"},
-            {phone_number: "Phone number"}
-          ])
-
+          sub_ref "E 1.1"
           required
         end
 

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -6,6 +6,7 @@ class AwardYears::V2022::QAEForms
         notice %(
           <p class=govuk-body>Please note your answers are being saved automatically in the background</p>
         )
+
         header :local_assessment_general_header, "General information" do
           context %(
             <p class=govuk-body>Thank you for conducting the local assessment for QAVS. Before starting the assessment, please read the QAVS local assessment guide that you can download from your dashboard page. The guide provides helpful tips on approaching the assessment.<p>

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -390,7 +390,7 @@ class AwardYears::V2022::QAEForms
           required
         end
 
-        text :nomination_local_assessment_worthy_of_honour_name, "Please give their name" do
+        text :nomination_local_assessment_worthy_of_honour_name, "Please give the name of the person you are recommending" do
           sub_ref "E 8.4"
           style "medium"
           conditional :nomination_local_assessment_form_member_worthy_of_honour, "yes"

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -3,6 +3,9 @@ class AwardYears::V2022::QAEForms
   class << self
     def qavs_step5
       @qavs_step5 ||= proc do
+        notice %(
+          <p class=govuk-body>Please note your answers are being saved automatically in the background</p>
+        )
         header :local_assessment_general_header, "General information" do
           context %(
             <p class=govuk-body>Thank you for conducting the local assessment for QAVS. Before starting the assessment, please read the QAVS local assessment guide that you can download from your dashboard page. The guide provides helpful tips on approaching the assessment.<p>
@@ -457,6 +460,20 @@ class AwardYears::V2022::QAEForms
               If you are not ready to submit yet, you can save your assessment and come back later.
             </p>
           )
+          alternative_notices [%(
+              <p class='govuk-hint'>
+                You will be able to edit the assessment any time before [LIEUTENANT_SUBMISSION_ENDS_TIME].
+              </p>
+            ),%(
+            <p class='govuk-hint'>
+              <strong>
+                Only main lieutenancy office users can submit the assessment.
+              </strong>
+            </p>
+            <p class='govuk-hint'>
+              Please save your assessment and inform your main point of contact at the lieutenancy office that it is ready for their review.
+            </p>
+          )]
         end
       end
     end

--- a/app/forms/qae_form_builder/assessor_details_question.rb
+++ b/app/forms/qae_form_builder/assessor_details_question.rb
@@ -1,6 +1,6 @@
 class QAEFormBuilder
   class AssessorDetailsQuestionValidator < QuestionValidator
-    NO_VALIDATION_SUB_FIELDS = [:secondary_assessor_name]
+    NO_VALIDATION_SUB_FIELDS = [:secondary_assessor_name, :phone]
     def errors
       result = super
 

--- a/app/forms/qae_form_builder/assessor_details_question.rb
+++ b/app/forms/qae_form_builder/assessor_details_question.rb
@@ -1,5 +1,24 @@
 class QAEFormBuilder
   class AssessorDetailsQuestionValidator < QuestionValidator
+    NO_VALIDATION_SUB_FIELDS = [:secondary_assessor_name]
+    def errors
+      result = super
+
+      if question.required?
+        question.required_sub_fields.each do |sub_field|
+          suffix = sub_field.keys[0]
+          if !question.input_value(suffix: suffix).present? && NO_VALIDATION_SUB_FIELDS.exclude?(suffix)
+            result[question.hash_key(suffix: suffix)] ||= ""
+            result[question.hash_key(suffix: suffix)] << " Can't be blank."
+          end
+        end
+      end
+
+      # need to add question-has-errors class
+      result[question.hash_key] ||= "" if result.any?
+
+      result
+    end
   end
 
   class AssessorDetailsQuestionDecorator < QuestionDecorator
@@ -8,10 +27,15 @@ class QAEFormBuilder
         sub_fields
       else
         [
-          { full_name: "Full name" },
-          { email: "Email" },
-          { phone_number: "Phone number" }
+          { primary_assessor_name: "Full name of the first assessor" },
+          { secondary_assessor_name: "Full name of the second assessor (if applicable)", ignore_validation: true }
         ]
+      end
+    end
+
+    def rendering_sub_fields
+      required_sub_fields.map do |f|
+        [f.keys.first, f.values.first]
       end
     end
   end

--- a/app/forms/qae_form_builder/step.rb
+++ b/app/forms/qae_form_builder/step.rb
@@ -160,6 +160,10 @@ class QAEFormBuilder
       end
     end
 
+    def notice notice
+      @step.notice = notice
+    end
+
     private
 
     def create_question builder_klass, klass, id, title, opts={}, &block
@@ -182,13 +186,17 @@ class QAEFormBuilder
       @submit.notice = notice
     end
 
+    def alternative_notices notices
+      @submit.alternative_notices = notices
+    end
+
     def style style
       @submit.style = style
     end
   end
 
   class StepSubmit
-    attr_accessor :notice, :style, :text
+    attr_accessor :notice, :style, :text, :alternative_notices
 
     def initialize text
       @text = text
@@ -196,7 +204,7 @@ class QAEFormBuilder
   end
 
   class Step
-    attr_accessor :title_key, :opts, :questions, :form, :context, :submit
+    attr_accessor :title_key, :opts, :questions, :form, :context, :submit, :notice
 
     def initialize form, title_key, opts={}
       @form = form

--- a/app/views/qae_form/_assessor_details_question.html.slim
+++ b/app/views/qae_form/_assessor_details_question.html.slim
@@ -1,11 +1,17 @@
 .govuk-fieldset role="group" aria-labelledby="q_#{question.key}_label" id="q_#{question.key}"
-  .govuk-form-group
-    label.govuk-label for="primary_assessor_name"
-      | Full name of the first assessor
-    span.govuk-error-message
-    input.govuk-input.govuk-input--width-20.js-trigger-autosave#primary_assessor_name type="text" name=question.input_name(suffix: 'primary_assessor_name') value=question.input_value(suffix: 'primary_assessor_name') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
-  .govuk-form-group
-    label.govuk-label for="secondary_assessor_name"
-      | Full name of the second assessor (if applicable)
-    span.govuk-error-message
-    input.govuk-input.govuk-input--width-20.js-trigger-autosave.not-required#secondary_assessor_name type="text" name=question.input_name(suffix: 'secondary_assessor_name') value=question.input_value(suffix: 'secondary_assessor_name') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
+  - question.rendering_sub_fields.each do |sub_field_block|
+    - sub_field_key = sub_field_block[0]
+    - sub_field_title = sub_field_block[1]
+    .govuk-form-group
+      label.govuk-label for=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key)
+        = sub_field_title
+      span.govuk-error-message
+        span.govuk-visually-hidden
+          | Error:
+        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
+          =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+      .clear
+
+      - klass = "govuk-input--width-20"
+      - klass <<(QAEFormBuilder::AssessorDetailsQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
+      input.govuk-input.js-trigger-autosave class=klass type="text" id=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key) name=question.input_name(suffix: sub_field_key) autocomplete="off" *possible_read_only_ops(question.step.opts[:id])

--- a/app/views/qae_form/_assessor_details_question.html.slim
+++ b/app/views/qae_form/_assessor_details_question.html.slim
@@ -1,16 +1,11 @@
 .govuk-fieldset role="group" aria-labelledby="q_#{question.key}_label" id="q_#{question.key}"
   .govuk-form-group
-    label.govuk-label for="full-name"
-      | Full name
+    label.govuk-label for="primary_assessor_name"
+      | Full name of the first assessor
     span.govuk-error-message
-    input.govuk-input.govuk-input--width-20.js-trigger-autosave#full-name type="text" name=question.input_name(suffix: 'full_name') value=question.input_value(suffix: 'full_name') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
+    input.govuk-input.govuk-input--width-20.js-trigger-autosave#primary_assessor_name type="text" name=question.input_name(suffix: 'primary_assessor_name') value=question.input_value(suffix: 'primary_assessor_name') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
   .govuk-form-group
-    label.govuk-label for="email"
-      | Email
+    label.govuk-label for="secondary_assessor_name"
+      | Full name of the second assessor (if applicable)
     span.govuk-error-message
-    input.govuk-input.govuk-input--width-20.js-trigger-autosave#email type="text" name=question.input_name(suffix: 'email') value=question.input_value(suffix: 'email') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
-  .govuk-form-group
-    label.govuk-label for="phone"
-      | Phone number
-    span.govuk-error-message
-    input.govuk-input.govuk-input--width-10.js-trigger-autosave#phone type="text" name=question.input_name(suffix: 'phone_number') value=question.input_value(suffix: 'phone_number') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])
+    input.govuk-input.govuk-input--width-20.js-trigger-autosave.not-required#secondary_assessor_name type="text" name=question.input_name(suffix: 'secondary_assessor_name') value=question.input_value(suffix: 'secondary_assessor_name') autocomplete="off" *possible_read_only_ops(question.step.opts[:id])

--- a/app/views/qae_form/_assessor_details_question.html.slim
+++ b/app/views/qae_form/_assessor_details_question.html.slim
@@ -12,6 +12,6 @@
           =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
       .clear
 
-      - klass = "govuk-input--width-20"
+      - klass = "#{sub_field_title.parameterize == "phone-number-optional" ? "govuk-input--width-10" : "govuk-input--width-20"}"
       - klass <<(QAEFormBuilder::AssessorDetailsQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
       input.govuk-input.js-trigger-autosave class=klass type="text" id=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key) name=question.input_name(suffix: sub_field_key) autocomplete="off" *possible_read_only_ops(question.step.opts[:id])

--- a/app/views/qae_form/_step.html.slim
+++ b/app/views/qae_form/_step.html.slim
@@ -10,7 +10,8 @@
       == step.context
 
     - if step.notice
-      == format_submit_notice(step.notice)
+      .govuk-inset-text
+        == format_submit_notice(step.notice)
     = render partial: "qae_form/question", collection: step.questions, locals: { answers: answers, attachments: attachments }
     - if step.submit
       = render partial: "qae_form/step_submit", object: step.submit, as: 'submit'

--- a/app/views/qae_form/_step.html.slim
+++ b/app/views/qae_form/_step.html.slim
@@ -5,8 +5,12 @@
       = (steps_first_char + step.index).chr
       ' .
       = step.title(current_user ? :user : :other)
+
     - if step.context
       == step.context
+
+    - if step.notice
+      == format_submit_notice(step.notice)
     = render partial: "qae_form/question", collection: step.questions, locals: { answers: answers, attachments: attachments }
     - if step.submit
       = render partial: "qae_form/step_submit", object: step.submit, as: 'submit'

--- a/app/views/qae_form/_step_submit.html.slim
+++ b/app/views/qae_form/_step_submit.html.slim
@@ -4,12 +4,9 @@
       = render "qae_form/pdf_link"
 
   - if submit.notice && (!current_lieutenant || current_lieutenant.role.advanced?)
-    br
-    .application-notice.info-notice
+    .govuk-inset-text
       == format_submit_notice(submit.notice)
   - if submit.alternative_notices && current_lieutenant.role.regular?
-    br
     - submit.alternative_notices.each do |n|
-      .application-notice.info-notice
+      .govuk-inset-text
         == format_submit_notice(n)
-    br

--- a/app/views/qae_form/_step_submit.html.slim
+++ b/app/views/qae_form/_step_submit.html.slim
@@ -6,7 +6,7 @@
   - if submit.notice && (!current_lieutenant || current_lieutenant.role.advanced?)
     .govuk-inset-text
       == format_submit_notice(submit.notice)
-  - if submit.alternative_notices && current_lieutenant.role.regular?
+  - if submit.alternative_notices && current_lieutenant && current_lieutenant.role.regular?
     - submit.alternative_notices.each do |n|
       .govuk-inset-text
         == format_submit_notice(n)

--- a/app/views/qae_form/_step_submit.html.slim
+++ b/app/views/qae_form/_step_submit.html.slim
@@ -7,4 +7,9 @@
     br
     .application-notice.info-notice
       == format_submit_notice(submit.notice)
+  - if submit.alternative_notices && current_lieutenant.role.regular?
+    br
+    - submit.alternative_notices.each do |n|
+      .application-notice.info-notice
+        == format_submit_notice(n)
     br

--- a/app/views/qae_form/confirm.html.slim
+++ b/app/views/qae_form/confirm.html.slim
@@ -9,7 +9,7 @@ h1.govuk-heading-xl Confirmation of submission
 
 .govuk-notification-banner.govuk-notification-banner--success role="alert" aria-labelledby="confirmation-banner-title" data-module="govuk-notification-banner"
   .govuk-notification-banner__header
-    h2.confirmation-banner__title#govuk-notification-banner-title
+    h2.govuk-notification-banner__title#govuk-notification-banner-title
       | Success
   .govuk-notification-banner__content
     p.govuk-body
@@ -22,7 +22,7 @@ h1.govuk-heading-xl Confirmation of submission
       ' You can still edit your submitted nomination up until
       = application_deadline(:submission_end)
       ' .
-  
+
 .govuk-width-container
   .article-related-positioning-container
   .article-container


### PR DESCRIPTION
### Local Assessment form
- adds automatic saving inset text at top of page
- amends question for assessor details

<img width="1094" alt="Screenshot 2021-09-02 at 16 37 28" src="https://user-images.githubusercontent.com/65811538/131874619-d048fe1b-50dd-4efb-a39c-071f3cbfc8b4.png">

- changes label for question E8.4

<img width="911" alt="Screenshot 2021-09-02 at 16 49 45" src="https://user-images.githubusercontent.com/65811538/131875991-315fb080-e00f-4023-b079-59a5fc83f4fd.png">

- adds in assessor details question at E8.6

<img width="869" alt="Screenshot 2021-09-02 at 16 39 45" src="https://user-images.githubusercontent.com/65811538/131875114-6278e4c2-35cb-4551-9973-0da1538a1edb.png">

- adds submission inset text for regular lieutenants (no change to advanced lieutenants message)

<img width="816" alt="Screenshot 2021-09-02 at 16 40 14" src="https://user-images.githubusercontent.com/65811538/131875253-4e6e7fa0-6991-4f89-b5ea-5208b57d68a1.png">

### Nomination form
- adds external link to Privacy Guidelines
- changes success header from black to white text on submission success message
