### PR TITLE
Introducing a new button that only navigates, bypassing validations and autosave

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -322,7 +322,7 @@ jQuery ->
     else
       $(this).closest(".js-step-link").attr("data-step")
 
-    window.FormValidation.validateStep()
+    window.FormValidation.validateStep() unless $(this).hasClass("bypass-validations")
 
     #
     # Make a switch to next section if this is not same tab only
@@ -379,7 +379,7 @@ jQuery ->
       else
         CollaboratorsLog.log("[STANDART MODE] ----------------------- ")
 
-        autosave()
+        autosave() unless $(this).hasClass('.bypass-autosave')
 
         if $(this).hasClass "js-next-link"
           if $("body").hasClass("tried-submitting")

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -16,8 +16,12 @@ footer
             - opts = possible_read_only_ops(step.opts[:id])
             - opts[:class] ||= ""
             - opts[:class] << " govuk-button"
-            = button_tag opts.merge(rel: "next", title: "Navigate to next part") do
-              ' Save and continue
+            - if opts.key?(:disabled)
+              = button_tag class: 'govuk-button bypass-autosave bypass-validations', rel: 'next' do
+                | Continue to the next step
+            - else
+              = button_tag opts.merge(rel: "next", title: "Navigate to next part") do
+                ' Save and continue
           - else
             = button_tag class: "govuk-button", rel: "next", title: "Navigate to next part" do
               - if next_step.local_assessment?

--- a/app/views/qae_form/_supporter_letter_attachments.html.slim
+++ b/app/views/qae_form/_supporter_letter_attachments.html.slim
@@ -1,2 +1,2 @@
-- if letter.present? && letter.support_letter_attachment.clean?
+- if letter.present? && letter.support_letter_attachment&.clean?
   = link_to "Download the #{adjective} letter of support (PDF)", letter_of_support_pdf_url(letter), class: "download-pdf-link govuk-link"


### PR DESCRIPTION
[UX issue 56]
This is for admins and assessors viewing a nomination, but with no edit access

![Screenshot from 2021-09-09 04-37-35](https://user-images.githubusercontent.com/758001/132645136-31fe1055-0de5-47e3-bc4f-653356105317.png)
