### PR TITLE
checks for empty string on email validation

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -116,7 +116,7 @@ window.FormValidation =
   validateEmailQuestion: (question) ->
     val = String(question.find("input[type='email']").val()).toLowerCase()
 
-    if not /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(val)
+    if not /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(val) && val != ""
       @logThis(question, "validateEmailQuestion", "Not a valid email")
       @addErrorMessage(question, "Not a valid email")
 


### PR DESCRIPTION
Issue 158 https://docs.google.com/spreadsheets/d/1gHPAcUI7i3dlo2i57Z_II7tUrZ_wVImA683OqEWuJKQ/edit#gid=0

When the email question was empty both error messages display so this PR adds a condition, as follows:
If the email question is empty then the error 'This field is required' will display.
If the email question is not empty but invalid then the error 'Not a valid email' will display.
<img width="778" alt="Screenshot 2021-09-29 at 09 09 07" src="https://user-images.githubusercontent.com/65811538/135228955-78b6537d-2f7f-407b-ab14-336f88f548dc.png">