### PR TITLE
remove params from paginate url

### DIFF
--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -29,6 +29,6 @@ h1.govuk-heading-xl
   = render("admin/form_answers/list_components/table", f: f)
   = render("admin/form_answers/bulk_assignment_button_bottom")
 
-  = paginate @form_answers
+  = paginate @form_answers, params: { search: nil }
 
 = render("admin/form_answers/bulk_assignment_modal")

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -41,4 +41,4 @@ h1.govuk-heading-xl
           th.govuk-table__header scope="col" View
         = render(partial: "list_body")
 
-  = paginate @form_answers
+  = paginate @form_answers, params: { search: nil }

--- a/app/views/lieutenant/form_answers/index.html.slim
+++ b/app/views/lieutenant/form_answers/index.html.slim
@@ -39,4 +39,4 @@ h1.govuk-heading-xl
             th.govuk-table__header scope="col" View
           = render(partial: "list_body")
 
-  = paginate @form_answers
+  = paginate @form_answers, params: { search: nil }


### PR DESCRIPTION
In dev environment the pagination breaks due to long urls. This PR removes the search params passed to paginate.

Issue 166 https://docs.google.com/spreadsheets/d/1gHPAcUI7i3dlo2i57Z_II7tUrZ_wVImA683OqEWuJKQ/edit#gid=0