### PR TITLE
Lieutenants

### DIFF
--- a/app/views/lieutenant/lieutenants/_list.html.slim
+++ b/app/views/lieutenant/lieutenants/_list.html.slim
@@ -23,7 +23,7 @@ div role="region" aria-label="list of lord lieutenancy office users" tabindex="0
       - else
         - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
           tr.govuk-table__row
-            td.govuk-table__cell = link_to lieutenant.full_name, edit_admin_lieutenant_path(lieutenant), class: "govuk-link"
+            td.govuk-table__cell = link_to lieutenant.full_name, edit_lieutenant_lieutenant_path(lieutenant), class: "govuk-link"
             td.govuk-table__cell = mail_to lieutenant.email, lieutenant.email, {class: "ellipsis govuk-link"}
             td.govuk-table__cell = lieutenant.role.humanize
             td.govuk-table__cell

--- a/app/views/lieutenant/lieutenants/_user_types.html.slim
+++ b/app/views/lieutenant/lieutenants/_user_types.html.slim
@@ -1,6 +1,6 @@
 .govuk-form-group
   = f.label :role, label: 'User type', class: "govuk-label--s"
-  = f.hint 'Main Lieutenancy users can'
+  = f.hint 'Regular Lieutenancy users can'
   ul.govuk-list.govuk-list--bullet.govuk-hint
     li access the nominations assigned to their Lieutenancy office
     li complete local assessment forms, but they cannot submit them
@@ -11,5 +11,5 @@
     li add Lieutenancy office users to their Lieutenancy office
   = f.input :role,
             as: :radio_buttons,
-            collection: [["Main Lieutenancy office user", "regular"], ["Advanced Lieutenancy office user", "advanced"]],
+            collection: [["Regular Lieutenancy office user", "regular"], ["Advanced Lieutenancy office user", "advanced"]],
             label: false

--- a/app/views/lieutenant/lieutenants/_user_types.html.slim
+++ b/app/views/lieutenant/lieutenants/_user_types.html.slim
@@ -1,15 +1,15 @@
 .govuk-form-group
   = f.label :role, label: 'User type', class: "govuk-label--s"
-  = f.hint 'Restricted Lieutenancy users can'
+  = f.hint 'Main Lieutenancy users can'
   ul.govuk-list.govuk-list--bullet.govuk-hint
     li access the nominations assigned to their Lieutenancy office
     li complete local assessment forms, but they cannot submit them
-  = f.hint 'Main Lieutenancy users can'
+  = f.hint 'Advanced Lieutenancy users can'
   ul.govuk-list.govuk-list--bullet.govuk-hint
     li complete and submit local assessment forms
     li recommend or not recommend each nomination for national assessment
     li add Lieutenancy office users to their Lieutenancy office
   = f.input :role,
             as: :radio_buttons,
-            collection: [["Restricted Lieutenancy office user", "regular"], ["Main Lieutenancy office user", "advanced"]],
+            collection: [["Main Lieutenancy office user", "regular"], ["Advanced Lieutenancy office user", "advanced"]],
             label: false

--- a/spec/features/admin/lieutenants/manage_spec.rb
+++ b/spec/features/admin/lieutenants/manage_spec.rb
@@ -20,7 +20,7 @@ describe "Admin: Lieutenant management" do
     fill_in "Email", with: "llkk@example.com"
 
     select "Bounty County", from: "Lieutenancy office"
-    choose "Main Lieutenancy office user"
+    choose "Regular Lieutenancy office user"
 
     click_button "Add user"
 

--- a/spec/features/admin/lieutenants/manage_spec.rb
+++ b/spec/features/admin/lieutenants/manage_spec.rb
@@ -20,7 +20,7 @@ describe "Admin: Lieutenant management" do
     fill_in "Email", with: "llkk@example.com"
 
     select "Bounty County", from: "Lieutenancy office"
-    choose "Restricted Lieutenancy office user"
+    choose "Main Lieutenancy office user"
 
     click_button "Add user"
 

--- a/spec/features/lieutenant/lieutenant_management_spec.rb
+++ b/spec/features/lieutenant/lieutenant_management_spec.rb
@@ -20,7 +20,7 @@ describe "Lieutenant: Lieutenant management" do
     fill_in "Last name", with: "KK"
 
     fill_in "Email", with: "llkk@example.com"
-    choose "Main Lieutenancy office user"
+    choose "Regular Lieutenancy office user"
 
     click_button "Create user"
 

--- a/spec/features/lieutenant/lieutenant_management_spec.rb
+++ b/spec/features/lieutenant/lieutenant_management_spec.rb
@@ -20,7 +20,7 @@ describe "Lieutenant: Lieutenant management" do
     fill_in "Last name", with: "KK"
 
     fill_in "Email", with: "llkk@example.com"
-    choose "Restricted Lieutenancy office user"
+    choose "Main Lieutenancy office user"
 
     click_button "Create user"
 


### PR DESCRIPTION
This PR renames the lieutenant roles in the user management screens.

Restricted is renamed to regular
Main is renamed to advanced

Issue 170 https://docs.google.com/spreadsheets/d/1gHPAcUI7i3dlo2i57Z_II7tUrZ_wVImA683OqEWuJKQ/edit#gid=0
<img width="823" alt="Screenshot 2021-10-01 at 09 59 12" src="https://user-images.githubusercontent.com/65811538/135593820-1883b506-7fa5-44bb-b018-1f4b1b8c2e2c.png">

Also fixes the path for lieutenants editing users (incorrectly using the admin path)