### PR TITLE
removes submitted status from filter

### DIFF
--- a/app/search/form_answer_status/lieutenant_filter.rb
+++ b/app/search/form_answer_status/lieutenant_filter.rb
@@ -3,10 +3,6 @@ class FormAnswerStatus::LieutenantFilter
   include NomineeActivityHelper
 
   OPTIONS = {
-    submitted: {
-      label: "Nomination submitted",
-      states: [:submitted]
-    },
     admin_eligible: {
       label: "Eligible by admin",
       states: [:admin_eligible]
@@ -59,12 +55,6 @@ class FormAnswerStatus::LieutenantFilter
       label: "No Royal approval",
       states: [
         :no_royal_approval
-      ]
-    },
-    not_eligible: {
-      label: "Ineligible - questionnaire",
-      states: [
-        :not_eligible
       ]
     },
     awarded: {


### PR DESCRIPTION
This PR removes submitted state from the default options for the lieutenants filter so that nominations will only show in the index once an admin has marked them as eligible.

Also removes a duplicated 'not-eligible' state