### PR TITLE
Fixing cookies for assessors and admins

### DIFF
--- a/app/assets/javascripts/application-admin.js.coffee
+++ b/app/assets/javascripts/application-admin.js.coffee
@@ -18,6 +18,7 @@
 #= require ./frontend/password-strength-indicator
 #= require ./frontend/textarea-autoResize
 #= require ./frontend/text-character-count
+#= require js.cookie
 #= require_tree ./admin
 #= require search
 #= require jquery-ui

--- a/app/assets/javascripts/frontend/ga-optout.js.coffee
+++ b/app/assets/javascripts/frontend/ga-optout.js.coffee
@@ -1,22 +1,2 @@
 jQuery ->
-  if !Cookies.get("general_cookie_consent_status")
-    $(".govuk-cookie-banner").attr("tabindex", "-1")
-    $(".govuk-cookie-banner").attr("aria-live", "polite")
-    $(".govuk-cookie-banner").removeAttr("hidden")
-    $(".govuk-cookie-banner").attr("role", "alert")
 
-    $(".govuk-cookie-banner .cookies-action").on "click", (e) ->
-      e.preventDefault()
-
-      Cookies.set("general_cookie_consent_status", 'yes', { expires: 3650 })
-      Cookies.set("analytics_cookies_consent_status", $(@).val(), { expires: 3650 })
-      $(".govuk-cookie-banner .initial-message").attr("hidden", "true")
-
-      if $(@).val() == "yes"
-        $(".govuk-cookie-banner .accept-message").removeAttr("hidden")
-      else
-        $(".govuk-cookie-banner .reject-message").removeAttr("hidden")
-
-    $(".govuk-cookie-banner .hide-message").on "click", (e) ->
-      e.preventDefault()
-      $(".govuk-cookie-banner").attr("hidden", "true")

--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -11,7 +11,8 @@ class ContentOnlyController < ApplicationController
                   :apply_for_queens_award_for_enterprise,
                   :sign_up_complete,
                   :submitted_nomination_successful,
-                  :pre_sign_in
+                  :pre_sign_in,
+                  :cookie_policy
                 ]
 
   before_action :get_current_form,

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,6 +26,8 @@ import Accordion from '../components/accordion';
 import AccessibleAutocomplete from '../vendor/accessible-autocomplete.min';
 import CheckboxMultiselect from '../vendor/checkbox-multiselect';
 
+import Cookies from 'js-cookie'
+
 frontend.initAll()
 
 $('.bulk-assign-lieutenants-link').on('click', function(e) {
@@ -288,3 +290,28 @@ Array.prototype.slice.call(document.querySelectorAll('table')).forEach(function(
   ResponsiveCellHeaders(table);
 })
 
+if (!Cookies.get("general_cookie_consent_status")) {
+  $(".govuk-cookie-banner").attr("tabindex", "-1")
+  $(".govuk-cookie-banner").attr("aria-live", "polite")
+  $(".govuk-cookie-banner").removeAttr("hidden")
+  $(".govuk-cookie-banner").attr("role", "alert")
+
+  $(".govuk-cookie-banner .cookies-action").on("click", function(e) {
+    e.preventDefault()
+
+    Cookies.set("general_cookie_consent_status", 'yes', { expires: 3650 })
+    Cookies.set("analytics_cookies_consent_status", $(this).val(), { expires: 3650 })
+    $(".govuk-cookie-banner .initial-message").attr("hidden", "true")
+
+    if ($(this).val() == "yes") {
+      $(".govuk-cookie-banner .accept-message").removeAttr("hidden")
+    } else {
+      $(".govuk-cookie-banner .reject-message").removeAttr("hidden")
+    }
+  })
+
+  $(".govuk-cookie-banner .hide-message").on("click", function(e) {
+    e.preventDefault()
+    $(".govuk-cookie-banner").attr("hidden", "true")
+  })
+}

--- a/app/views/content_only/cookie_policy.html.slim
+++ b/app/views/content_only/cookie_policy.html.slim
@@ -34,6 +34,10 @@ h1.govuk-heading-xl
               td.govuk-table__cell These help us count how many people visit APPLY.QAVS.DCMS.GOV.UK by tracking if you’ve visited before
               td.govuk-table__cell 2 years
             tr.govuk-table__row
+              td.govuk-table__cell _gat
+              td.govuk-table__cell These help us throttle requests to Google Analytics
+              td.govuk-table__cell 1 minute
+            tr.govuk-table__row
               td.govuk-table__cell _gid
               td.govuk-table__cell These help us count how many people visit APPLY.QAVS.DCMS.GOV.UK by tracking if you’ve visited before
               td.govuk-table__cell 24 hours

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -69,6 +69,10 @@
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
+      = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
+      = link_to "Cookie Settings", cookies_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
       ' Built by
       = link_to "The Queen's Awards Office", "http://blogs.bis.gov.uk/queensawards/", class: 'govuk-footer__link'
 

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -79,6 +79,10 @@
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
+      = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
+      = link_to "Cookie Settings", cookies_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
       ' Built by
       = link_to "The Queen's Awards Office", "http://blogs.bis.gov.uk/queensawards/", class: 'govuk-footer__link'
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -103,28 +103,6 @@
   - if Rails.env.test?
     = javascript_tag("$.fx.off = true;")
 
-  - if ENV["GOOGLE_ANALYTICS_ID"].present?
-    / Google Analytics
-    script type="text/javascript"
-      | if (Cookies.get("analytics_cookies_consent_status") === "yes") {
-      |   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      |   ga('create', '#{ENV["GOOGLE_ANALYTICS_ID"]}', 'auto');
-
-      |   ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
-      |   ga('govuk_shared.require', 'linker');
-      |   ga('govuk_shared.linker.set', 'anonymizeIp', true);
-      |   ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
-
-      - if current_user
-        | ga('set', 'userId', '#{current_user.id}');
-        | ga('set', 'dimension1', '#{current_user.id}');
-
-      |   ga('set', 'anonymizeIp', true);
-      |   ga('send', 'pageview');
-      |   ga('govuk_shared.send', 'pageview');
-      | }
-
-
 = render template: 'layouts/govuk_template'
 
 - if should_enable_js?

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -139,6 +139,30 @@
 
     <% if should_enable_js? %>
       <%= yield :body_end %>
+
+      <% if ENV["GOOGLE_ANALYTICS_ID"].present? %>
+        <script type="text/javascript">
+          $(function() {
+            if (Cookies.get("analytics_cookies_consent_status") === "yes") {
+              (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+              ga('create', '#{ENV["GOOGLE_ANALYTICS_ID"]}', 'auto');
+
+              ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
+              ga('govuk_shared.require', 'linker');
+              ga('govuk_shared.linker.set', 'anonymizeIp', true);
+              ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+              <% if current_user %>
+                ga('set', 'userId', '<%= current_user.id %>');
+                ga('set', 'dimension1', '<%= current_user.id %>');
+              <% end %>
+
+              ga('set', 'anonymizeIp', true);
+              ga('send', 'pageview');
+              ga('govuk_shared.send', 'pageview');
+            }
+          });
+        </script>
+      <% end %>
     <% end %>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "css-minimizer-webpack-plugin": "^3.0.2",
     "govuk-frontend": "^3.13.0",
     "jquery": "^3.6.0",
+    "js-cookie": "^3.0.1",
     "micromodal": "^0.4.6",
     "mini-css-extract-plugin": "^2.0.0",
     "node-sass": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,6 +3372,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
- The cookie banner, settings page and policy pages arent showing for admin & assessor users 
- there is one cookie missing from the cookie policy and that is the _gat cookie. Please add the details of this cookie to the policy. 

Card: https://app.asana.com/0/1200175839265057/1201036488332009/f