### PR TITLE
PErsisting search in database to avoid long urls

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -55,11 +55,25 @@ class Admin::FormAnswersController < Admin::BaseController
   end
 
   def index
-    params[:search] ||= FormAnswerSearch.default_search
-    params[:search].permit!
+    search_params = params[:search] || FormAnswerSearch.default_search
     authorize :form_answer, :index?
 
-    @search = FormAnswerSearch.new(target_scope, current_admin).search(params[:search])
+    if params[:search] && params[:search][:search_filter] != FormAnswerSearch.default_search[:search_filter]
+      search = NominationSearch.create(serialized_query: params[:search].to_json)
+      redirect_to admin_form_answers_path(search_id: search.id)
+    end
+
+    if params[:search_id]
+      search = NominationSearch.find_by_id(params[:search_id])
+
+      if search.present?
+        payload = JSON.parse(search.serialized_query)
+        search_params[:search_filter] = payload['search_filter']
+        search_params[:query] = payload['query']
+      end
+    end
+
+    @search = FormAnswerSearch.new(target_scope, current_admin).search(search_params)
     @search.ordered_by = "company_or_nominee_name" unless @search.ordered_by
     @form_answers = @search.results
                       .with_comments_counters

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -135,11 +135,11 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def state_text
-    I18n.t(object.state.to_s, scope: "form_answers.state")
+    ""# I18n.t(object.state.to_s, scope: "form_answers.state")
   end
 
   def state_short_text
-    I18n.t(object.state.to_s, scope: "form_answers.state_short").html_safe
+    ""#I18n.t(object.state.to_s, scope: "form_answers.state_short").html_safe
   end
 
   def eligibility_state

--- a/app/models/nomination_search.rb
+++ b/app/models/nomination_search.rb
@@ -1,0 +1,2 @@
+class NominationSearch < ApplicationRecord
+end

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -12,7 +12,7 @@ h1.govuk-heading-xl
                                               activity_options: FormAnswerStatus::AssessorFilter.collection('activity type'),
                                               assigned_county_options: FormAnswerStatus::AssessorFilter.collection('assigned county')
 
-  = hidden_field_tag "search[sort]", params[:search][:sort]
+  = hidden_field_tag "search[sort]", params.dig(:search, :sort)
 
   .govuk-button-group
     = f.submit 'Search and apply filters', class: 'govuk-button', id: 'apply-nomination-filters'

--- a/app/views/lieutenant/form_answers/index.html.slim
+++ b/app/views/lieutenant/form_answers/index.html.slim
@@ -11,7 +11,7 @@ h1.govuk-heading-xl
     = render "filters", f: f,
                         activity_options: FormAnswerStatus::LieutenantFilter.collection('activity type')
 
-  = hidden_field_tag "search[sort]", params[:search][:sort]
+  = hidden_field_tag "search[sort]", params.dig(:search, :sort)
 
   .govuk-button-group
     = f.submit 'Search and apply filters', class: 'govuk-button', id: 'apply-nomination-filters'

--- a/db/migrate/20211011083451_create_nomination_searches.rb
+++ b/db/migrate/20211011083451_create_nomination_searches.rb
@@ -1,0 +1,7 @@
+class CreateNominationSearches < ActiveRecord::Migration[6.0]
+  def change
+    create_table :nomination_searches do |t|
+      t.text :serialized_query
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25,6 +25,8 @@ COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: accounts; Type: TABLE; Schema: public; Owner: -
 --
@@ -42,6 +44,7 @@ CREATE TABLE public.accounts (
 --
 
 CREATE SEQUENCE public.accounts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -130,6 +133,7 @@ CREATE TABLE public.admins (
 --
 
 CREATE SEQUENCE public.admins_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -166,6 +170,7 @@ CREATE TABLE public.aggregated_award_year_pdfs (
 --
 
 CREATE SEQUENCE public.aggregated_award_year_pdfs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -217,6 +222,7 @@ CREATE TABLE public.assessor_assignments (
 --
 
 CREATE SEQUENCE public.assessor_assignments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -272,6 +278,7 @@ CREATE TABLE public.assessors (
 --
 
 CREATE SEQUENCE public.assessors_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -307,6 +314,7 @@ CREATE TABLE public.audit_logs (
 --
 
 CREATE SEQUENCE public.audit_logs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -343,6 +351,7 @@ CREATE TABLE public.award_years (
 --
 
 CREATE SEQUENCE public.award_years_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -446,6 +455,7 @@ CREATE TABLE public.comments (
 --
 
 CREATE SEQUENCE public.comments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -480,6 +490,7 @@ CREATE TABLE public.deadlines (
 --
 
 CREATE SEQUENCE public.deadlines_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -516,6 +527,7 @@ CREATE TABLE public.draft_notes (
 --
 
 CREATE SEQUENCE public.draft_notes_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -551,6 +563,7 @@ CREATE TABLE public.eligibilities (
 --
 
 CREATE SEQUENCE public.eligibilities_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -585,6 +598,7 @@ CREATE TABLE public.email_notifications (
 --
 
 CREATE SEQUENCE public.email_notifications_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -622,6 +636,7 @@ CREATE TABLE public.feedbacks (
 --
 
 CREATE SEQUENCE public.feedbacks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -661,6 +676,7 @@ CREATE TABLE public.form_answer_attachments (
 --
 
 CREATE SEQUENCE public.form_answer_attachments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -691,6 +707,7 @@ CREATE TABLE public.form_answer_progresses (
 --
 
 CREATE SEQUENCE public.form_answer_progresses_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -726,6 +743,7 @@ CREATE TABLE public.form_answer_transitions (
 --
 
 CREATE SEQUENCE public.form_answer_transitions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -793,6 +811,7 @@ CREATE TABLE public.form_answers (
 --
 
 CREATE SEQUENCE public.form_answers_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -912,6 +931,35 @@ ALTER SEQUENCE public.lieutenants_id_seq OWNED BY public.lieutenants.id;
 
 
 --
+-- Name: nomination_searches; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.nomination_searches (
+    id bigint NOT NULL,
+    serialized_query text
+);
+
+
+--
+-- Name: nomination_searches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.nomination_searches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: nomination_searches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.nomination_searches_id_seq OWNED BY public.nomination_searches.id;
+
+
+--
 -- Name: palace_attendees; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -944,6 +992,7 @@ CREATE TABLE public.palace_attendees (
 --
 
 CREATE SEQUENCE public.palace_attendees_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -978,6 +1027,7 @@ CREATE TABLE public.palace_invites (
 --
 
 CREATE SEQUENCE public.palace_invites_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1011,6 +1061,7 @@ CREATE TABLE public.previous_wins (
 --
 
 CREATE SEQUENCE public.previous_wins_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1048,6 +1099,7 @@ CREATE TABLE public.scans (
 --
 
 CREATE SEQUENCE public.scans_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1088,6 +1140,7 @@ CREATE TABLE public.settings (
 --
 
 CREATE SEQUENCE public.settings_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1120,6 +1173,7 @@ CREATE TABLE public.site_feedbacks (
 --
 
 CREATE SEQUENCE public.site_feedbacks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1156,6 +1210,7 @@ CREATE TABLE public.support_letter_attachments (
 --
 
 CREATE SEQUENCE public.support_letter_attachments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1201,6 +1256,7 @@ CREATE TABLE public.support_letters (
 --
 
 CREATE SEQUENCE public.support_letters_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2503,6 +2559,7 @@ CREATE TABLE public.users (
 --
 
 CREATE SEQUENCE public.users_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2534,6 +2591,7 @@ CREATE TABLE public.version_associations (
 --
 
 CREATE SEQUENCE public.version_associations_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2570,6 +2628,7 @@ CREATE TABLE public.versions (
 --
 
 CREATE SEQUENCE public.versions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2736,6 +2795,13 @@ ALTER TABLE ONLY public.group_leaders ALTER COLUMN id SET DEFAULT nextval('publi
 --
 
 ALTER TABLE ONLY public.lieutenants ALTER COLUMN id SET DEFAULT nextval('public.lieutenants_id_seq'::regclass);
+
+
+--
+-- Name: nomination_searches id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nomination_searches ALTER COLUMN id SET DEFAULT nextval('public.nomination_searches_id_seq'::regclass);
 
 
 --
@@ -2997,6 +3063,14 @@ ALTER TABLE ONLY public.group_leaders
 
 ALTER TABLE ONLY public.lieutenants
     ADD CONSTRAINT lieutenants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: nomination_searches nomination_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.nomination_searches
+    ADD CONSTRAINT nomination_searches_pkey PRIMARY KEY (id);
 
 
 --
@@ -3861,6 +3935,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210817084427'),
 ('20210819140008'),
 ('20210826124140'),
-('20210831085355');
+('20210831085355'),
+('20211011083451');
 
 


### PR DESCRIPTION
Instead of passing params around
persist all search parameters in database and then pagination should only have search_id as actual filtering parameter