### PR TITLE
lieutenant accessibility audit fixes

### DIFF
--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -1,3 +1,5 @@
+$govuk-dark-grey: 	#505a5f;
+
 $black-true:      #000;
 $black:           #333;
 $less-black:      #262626;
@@ -33,4 +35,3 @@ $pagination-background: #e6e6e6;
 $pagination-border: #adadad;
 
 $header-hover: #444;
-

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -997,7 +997,7 @@ table .ellipsis {
 }
 
 .muted {
-  color: $grey;
+  color: $govuk-dark-grey;
 }
 
 // Filterable Dropdowns

--- a/app/forms/award_years/v2022/qavs/qavs_step1.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step1.rb
@@ -7,7 +7,7 @@ class AwardYears::V2022::QAEForms
           <p class=govuk-body>Please note your answers are being saved automatically in the background.</p>
         )
 
-        header :nominee_details_header, "Group Details" do
+        header :nominee_details_header, "Group details" do
           ref "A 1"
         end
 

--- a/app/forms/award_years/v2022/qavs/qavs_step2.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step2.rb
@@ -7,9 +7,8 @@ class AwardYears::V2022::QAEForms
           <p class=govuk-body>Please note your answers are being saved automatically in the background.</p>
         )
 
-        header :recommendation, "" do
-          header "About this section"
-          header_context %(
+        header :recommendation, "About this section" do
+          help "About this section", %(
             <p class='govuk-body'>
               In this section, please explain how your nominated group has made a significant contribution in its area of activity. We are looking for groups that have given excellent service to their beneficiaries and communities; have delivered their service in innovative ways, and have shown other examples of selfless voluntary service that distinguish their work.
               <strong>Please answer each question, noting the word limits, explaining what achievements make the nominated group stand out from others.</strong>

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -23,13 +23,13 @@ class AwardYears::V2022::QAEForms
           ])
         end
 
-        comment :nominee_details_hint, "" do
-          form_hint %(
-            Questions 1.2 to 1.7 have information pre-filled by the nominator. Please double-check and amend as necessary. It’s important that these details are correct so that we can contact the successful group leaders in confidence and use the right group name in any announcement.
-          )
-        end
 
         text :nomination_local_assessment_form_nominee_name, "Group name" do
+          header_context %(
+            <p class=govuk-body>
+              Questions 1.2 to 1.7 have information pre-filled by the nominator. Please double-check and amend as necessary. It’s important that these details are correct so that we can contact the successful group leaders in confidence and use the right group name in any announcement.
+            </p>
+          )
           sub_ref "E 1.2"
           form_hint "Please check that the group name given by the nominator is correct."
           required

--- a/app/forms/qae_form_builder/question.rb
+++ b/app/forms/qae_form_builder/question.rb
@@ -103,7 +103,13 @@ class QAEFormBuilder
       type = delegate_obj.class.name.demodulize.underscore
 
       legend_types = [
-        "header_question"
+        "header_question",
+        "options_question",
+        "checkbox_seria_question",
+        "confirm_question",
+        "address_question",
+        "assessor_details_question",
+        "comment_question"
       ]
 
       legend_types.include?(type)

--- a/app/views/admin/form_answers/_details_and_letters_of_support.html.slim
+++ b/app/views/admin/form_answers/_details_and_letters_of_support.html.slim
@@ -1,4 +1,4 @@
-h3.govuk-heading-m
+h2.govuk-heading-m
   | Nomination and local assessment form
 
 .govuk-button-group
@@ -9,7 +9,7 @@ h3.govuk-heading-m
 
 - if @form_answer.support_letters.any?
   #section-letters-of-support class="govuk-!-margin-top-7"
-    h3.govuk-heading-m
+    h2.govuk-heading-m
       | Letters of support
     = render "admin/form_answer_attachments/support_letter", support_letter: @form_answer.support_letters.first, adjective: 'first'
     - if @form_answer.support_letters.second.present?

--- a/app/views/group_leader/dashboard/show.html.slim
+++ b/app/views/group_leader/dashboard/show.html.slim
@@ -14,10 +14,10 @@
           =< @deadlines.end_of_embargo.strftime("%-d %B %Y")
           | . Before this date, you must not make any announcements about your Award, either to volunteers or outside your group.
 
-    h3.govuk-heading-m
+    h2.govuk-heading-m
       | What you need to do
 
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | By
       =<> @deadlines.buckingham_palace_confirm_press_book_notes.strftime("%-d %B %Y")
       | &mdash; confirm group name and citation &nbsp;
@@ -34,7 +34,7 @@
     = link_to "Confirm group name and citation", edit_group_leader_citation_path(@citation), class: "govuk-button govuk-button--start"
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | Between 1 April and
       =<> @deadlines.end_of_embargo.strftime("%-d %B %Y")
       | &mdash; prepare press coverage
@@ -60,7 +60,7 @@
             = link_to "The Queen's Award for Voluntary Service logo in various formats"
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | By
       =<> @deadlines.buckingham_palace_reception_attendee_information_due_by.strftime("%-d %B %Y")
       | &mdash; submit details for Royal Garden Party &nbsp;
@@ -80,17 +80,17 @@
 
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    h3.govuk-heading-m
+    h2 .govuk-heading-m
       | Announcement and event dates
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | 2 June 2022 &mdash; awards officially announced
     p.govuk-body
       | Successful groups, including your group, are announced in Gazette, GOV.UK and on the QAVS website.
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | June to September 2022 &mdash; Lord-Lieutenant presents the Award
     p.govuk-body
       | The Lord-Lieutenant of your local county, as The Queen's representative, will present your group with a certificate and a commemorative crystal at a local ceremony. They will be in touch to arrange a suitable date and time for you.
-    h4.govuk-heading-s
+    h3.govuk-heading-s
       | May to July 2023 &mdash; Royal Garden Party
     p.govuk-body
       | The two representatives from your group that you have selected attend a Royal Garden Party at Buckingham Palace in London or the Palace of Holyroodhouse in Edinburgh.

--- a/app/views/lieutenant/dashboard/show.html.slim
+++ b/app/views/lieutenant/dashboard/show.html.slim
@@ -20,7 +20,7 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      h3.govuk-heading-m
+      h2.govuk-heading-m
         | Other useful resources
       p.govuk-body
         | You can also download promotional materials to help raise awareness of the award.

--- a/app/views/lieutenant/form_answers/_list_body.html.slim
+++ b/app/views/lieutenant/form_answers/_list_body.html.slim
@@ -2,7 +2,9 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj]), class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj]),
+                  aria: { label: "View nomination for #{obj.company_or_nominee_name}" },
+                  class: 'govuk-link' do
           - unless obj.nominee_name.nil?
             span
               = obj.nominee_name
@@ -26,4 +28,8 @@ tbody.govuk-table__body
         span.muted
           = obj.last_updated_by
 
-      td.govuk-table__cell = link_to "View", lieutenant_form_answer_path(obj), class: 'govuk-link'
+      td.govuk-table__cell
+        = link_to "View",
+                  lieutenant_form_answer_path(obj),
+                  aria: { label: "View nomination for #{obj.company_or_nominee_name}" },
+                  class: 'govuk-link'

--- a/app/views/qae_form/_address_question.html.slim
+++ b/app/views/qae_form/_address_question.html.slim
@@ -1,4 +1,4 @@
-div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label"
+div role="group" id="q_#{question.key}"
   - question.rendering_sub_fields.each do |sub_field_block|
     - sub_field_key = sub_field_block[0]
     - sub_field_title = sub_field_block[1]

--- a/app/views/qae_form/_assessor_details_question.html.slim
+++ b/app/views/qae_form/_assessor_details_question.html.slim
@@ -1,4 +1,4 @@
-.govuk-fieldset role="group" aria-labelledby="q_#{question.key}_label" id="q_#{question.key}"
+.govuk-fieldset role="group" id="q_#{question.key}"
   - question.rendering_sub_fields.each do |sub_field_block|
     - sub_field_key = sub_field_block[0]
     - sub_field_title = sub_field_block[1]

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -1,91 +1,83 @@
 - if question.header
-  h3.govuk-heading-m
+  h2.govuk-heading-l
     = question.header
-  - if question.header_context
-    span
-      == question.header_context
-- else
-  - is_sub_question = question.fieldset_classes.include?('sub-question')
-  fieldset class=question.fieldset_classes data=question.fieldset_data_hash
-    = condition_divs question do
-      .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
-        - ref = question.ref ? question.ref : question.sub_ref
-        - if question.title != "" || question.show_ref_always.present?
-          - if question.label_as_legend?
-            legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
-              - if question.ref || question.sub_ref
-                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
-                  span.todo
-                    = ref.to_s
-              - unless question.title.blank?
-                - if is_sub_question
-                  == question.title
-                - else
-                  span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold govuk-!-display-block"
-                    == question.title
+- if question.header_context
+  == question.header_context
+fieldset class=question.fieldset_classes data=question.fieldset_data_hash
+  = condition_divs question do
+    .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+      - ref = question.ref ? question.ref : question.sub_ref
+      - if question.title != "" || question.show_ref_always.present?
+        - if question.label_as_legend?
+          legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              - font_size = question.delegate_obj.is_a?(QAEFormBuilder::HeaderQuestion) ? "govuk-!-font-size-36" : "govuk-!-font-size-24"
+              span class="govuk-body #{ font_size } govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
 
-              = render "qae_form/question_sub_title", question: question
-
-          - else
-            legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
-            label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
-              - if question.ref || question.sub_ref
-                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
-                  span.todo
-                    = ref.to_s
-              - unless question.title.blank?
-                - if is_sub_question
-                  == question.title
-                - else
-                  span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                    == question.title
-
-              = render "qae_form/question_sub_title", question: question
+            = render "qae_form/question_sub_title", question: question
 
         - else
-          - if question.ref || question.sub_ref
-            .if-js-hide
-              label.govuk-label for="q_#{question.key}" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
-                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
-                  span.visuallyhidden
-                    = ref.to_s
-                  span.todo
-                    = ref.to_s
+          legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+          label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
 
-        - if question.delegate_obj.is_a?(QAEFormBuilder::HeaderQuestion)
-          - if question.ref || question.sub_ref
-              span.question-context.question-debug.govuk-hint
-                = "Please note #{(question.ref || question.sub_ref).delete(" ")} is just a heading for the following sub-questions."
-          - if question.context
+            = render "qae_form/question_sub_title", question: question
+
+      - else
+        - if question.ref || question.sub_ref
+          .if-js-hide
+            label.govuk-label for="q_#{question.key}" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.visuallyhidden
+                  = ref.to_s
+                span.todo
+                  = ref.to_s
+
+      - if question.delegate_obj.is_a?(QAEFormBuilder::HeaderQuestion)
+        - if question.ref || question.sub_ref
+            span.question-context.question-debug.govuk-hint
+              = "Please note #{(question.ref || question.sub_ref).delete(" ")} is just a heading for the following sub-questions."
+        - if question.context
+          == question.context
+        - for help in question.help
+          == help.text
+      - else
+        - if question.context
+          span.question-context.question-debug.govuk-hint
             == question.context
-          - for help in question.help
+        - for help in question.help
+          span.question-context.question-debug.govuk-hint
             == help.text
-        - else
-          - if question.context
-            span.question-context.question-debug.govuk-hint
-              == question.context
-          - for help in question.help
-            span.question-context.question-debug.govuk-hint
-              == help.text
 
-        - question.hint.each_with_index do |help, index|
-          details.govuk-details data-module='govuk-details'
-            - if help.title.present?
-              summary.govuk-details__summary
-                span.govuk-details__summary-text
-                  = help.title.html_safe
-            .govuk-details__text
-              == help.text
+      - question.hint.each_with_index do |help, index|
+        details.govuk-details data-module='govuk-details'
+          - if help.title.present?
+            summary.govuk-details__summary
+              span.govuk-details__summary-text
+                = help.title.html_safe
+          .govuk-details__text
+            == help.text
 
-        span.govuk-error-message
-          - if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key].present? && @form_answer.validator_errors[question.hash_key].is_a?(String)
-            span.govuk-visually-hidden
-              | Error:
-            =< @form_answer.validator_errors[question.hash_key]
-        - unless question.form_hint.blank?
-          span.govuk-hint = question.form_hint
-        = render partial: "qae_form/#{question.delegate_obj.class.name.demodulize.underscore}", object: question, as: 'question', locals: {answers: answers, attachments: attachments}
+      span.govuk-error-message
+        - if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key].present? && @form_answer.validator_errors[question.hash_key].is_a?(String)
+          span.govuk-visually-hidden
+            | Error:
+          =< @form_answer.validator_errors[question.hash_key]
+      - unless question.form_hint.blank?
+        span.govuk-hint = question.form_hint
+      = render partial: "qae_form/#{question.delegate_obj.class.name.demodulize.underscore}", object: question, as: 'question', locals: {answers: answers, attachments: attachments}
 
-        / Conditional hints
-        - if question.can_have_conditional_hints?
-          = render "qae_form/conditional_hints/list", question: question
+      / Conditional hints
+      - if question.can_have_conditional_hints?
+        = render "qae_form/conditional_hints/list", question: question


### PR DESCRIPTION
this PR addresses the following accessibility issues:
### nomination and local assessment forms
- missing legends on fieldsets
- missing or orphaned labels
- heading sequencing
- removes aria-labelledby reference where missing (label is legend)
- keeps stylings as requested by UX team

### nominations index
- adds more detail to aria labels for links
- uses grey with better contrast for usernames