### PR TITLE
Added empty string as alt text for decorative spinner images

### DIFF
--- a/app/views/qae_form/_textarea_question.html.slim
+++ b/app/views/qae_form/_textarea_question.html.slim
@@ -6,7 +6,7 @@
 
 .if-no-js-hide
   .js-ckeditor-spinner-block
-    = image_tag "textarea_spinner.gif"
+    = image_tag "textarea_spinner.gif", alt: ""
     span.govuk-body
       | Loading Editor ...
 


### PR DESCRIPTION
Resolving this wave error: 

![Screenshot 2021-10-26 at 09 21 35](https://user-images.githubusercontent.com/84323332/138837384-a21d869f-6d10-4d20-9368-b77fbfdf9e49.png)

