### PR TITLE
Changing accessibility statement link in footer

### DIFF
--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -72,7 +72,7 @@ title = content_for?(:title) ? yield(:title) : "Admin - Queen's Award for Volunt
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_path, class: 'govuk-footer__link'
+      = link_to "Accessibility Statement", 'https://qavs.dcms.gov.uk/accessibility-statement-system/', class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -82,7 +82,7 @@ title = content_for?(:title) ? yield(:title) : "Assessor - Queen's Award for Vol
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_path, class: 'govuk-footer__link'
+      = link_to "Accessibility Statement", 'https://qavs.dcms.gov.uk/accessibility-statement-system/', class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item

--- a/app/views/layouts/application-judge.html.slim
+++ b/app/views/layouts/application-judge.html.slim
@@ -99,7 +99,7 @@ title = content_for?(:title) ? yield(:title) : "Judge - Queen's Award for Volunt
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_path, class: 'govuk-footer__link'
+      = link_to "Accessibility Statement", 'https://qavs.dcms.gov.uk/accessibility-statement-system/', class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item

--- a/app/views/layouts/application-lieutenant.html.slim
+++ b/app/views/layouts/application-lieutenant.html.slim
@@ -71,7 +71,7 @@ title = content_for?(:title) ? yield(:title) : "Lieutenant - Queen's Award for V
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_path, class: 'govuk-footer__link'
+      = link_to "Accessibility Statement", 'https://qavs.dcms.gov.uk/accessibility-statement-system/', class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -88,7 +88,7 @@
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_path, class: 'govuk-footer__link'
+      = link_to "Accessibility Statement", 'https://qavs.dcms.gov.uk/accessibility-statement-system/', class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookie_policy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item


### PR DESCRIPTION
This PR changes the link for the accessibility statement in footer to a page in the marketing website.

New page URL: https://qavs.dcms.gov.uk/accessibility-statement-system/

no visual changes.

Card: https://app.asana.com/0/1199154381249427/1201337505430969/f