### PR TITLE
🔧  fixes add user button

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -18,7 +18,7 @@
         .govuk-grid-row
           = render "shared/users/search_count"
         .govuk-button-group
-          = button_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user govuk-button pull-right', method: :get do
+          = link_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user govuk-button pull-right', role: 'button' do
             = t("admin.users.new_button.#{controller_name}")
         .clear
 

--- a/app/views/lieutenant/lieutenants/index.html.slim
+++ b/app/views/lieutenant/lieutenants/index.html.slim
@@ -18,11 +18,11 @@
       = render "shared/users/search_count"
 
     .govuk-button-group
-      = button_to t("admin.users.new_button.#{controller_name}"),
+      = link_to t("admin.users.new_button.#{controller_name}"),
                   new_lieutenant_lieutenant_path,
                   class: 'new-user govuk-button',
                   id: 'add-lieutenant',
-                  method: :get
+                  role: 'button'
     .clear
 
     = render 'list', resources: @resources, f: f

--- a/spec/acceptance/steps/admin_user_management_steps.rb
+++ b/spec/acceptance/steps/admin_user_management_steps.rb
@@ -4,7 +4,7 @@ end
 
 step "I create new user" do
   step "I go to user management page"
-  click_button "Add nominator"
+  click_link "Add nominator"
 
   fill_in 'Email', with: 'user@example.com'
   fill_in 'First name', with: "Dummy"

--- a/spec/features/admin/assessors/manage_spec.rb
+++ b/spec/features/admin/assessors/manage_spec.rb
@@ -12,7 +12,7 @@ describe "Admin: Assessor management" do
   it "can create a assessor" do
     visit admin_assessors_path
 
-    click_button "Add national assessor"
+    click_link "Add national assessor"
 
     fill_in "First name", with: "LL"
     fill_in "Last name", with: "KK"

--- a/spec/features/admin/lieutenants/manage_spec.rb
+++ b/spec/features/admin/lieutenants/manage_spec.rb
@@ -12,7 +12,7 @@ describe "Admin: Lieutenant management" do
   it "can create a lieutenant" do
     visit admin_lieutenants_path
 
-    click_button "Add Lieutenancy office user"
+    click_link "Add Lieutenancy office user"
 
     fill_in "First name", with: "LL"
     fill_in "Last name", with: "KK"

--- a/spec/features/lieutenant/lieutenant_management_spec.rb
+++ b/spec/features/lieutenant/lieutenant_management_spec.rb
@@ -14,7 +14,7 @@ describe "Lieutenant: Lieutenant management" do
   it "can create a lieutenant" do
     visit lieutenant_lieutenants_path
 
-    click_button "add-lieutenant"
+    click_link "add-lieutenant"
 
     fill_in "First name", with: "LL"
     fill_in "Last name", with: "KK"


### PR DESCRIPTION
this PR fixes the add user button in admin and lieutenant user management pages. As there is no form to submit, a link should be used instead of a button tag.

![Screenshot 2021-11-09 at 11 00 13](https://user-images.githubusercontent.com/65811538/140912498-11611cf2-10b6-4ef7-b409-df611f97359d.png)


