### PR TITLE
improves accessibility

### DIFF
--- a/app/views/admin/group_leaders/edit.html.slim
+++ b/app/views/admin/group_leaders/edit.html.slim
@@ -1,3 +1,8 @@
+- title t("admin.users.edit_button.#{controller_name}")
+
+- content_for :before_main_content do
+  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")
 

--- a/app/views/form_award_eligibilities/basic_questions/_years_operating.html.slim
+++ b/app/views/form_award_eligibilities/basic_questions/_years_operating.html.slim
@@ -1,5 +1,7 @@
 .question-body
   p.question-context
     = @eligibility.class.hint(question)
-  = f.input :years_operating, as: :numeric, label: @eligibility.class.label(step).html_safe, input_html: { class: 'tiny' }, label_html: { class: 'govuk-label govuk-label--l' }
+  legend.govuk-fieldset__legend
+    = f.label @eligibility.class.label(step).html_safe, class: 'govuk-label govuk-label--l', tag: 'h2'
+  = f.input :years_operating, as: :numeric, input_html: { class: 'tiny' }, label: false
   span.clear

--- a/app/views/form_award_eligibilities/basic_questions/_years_operating.html.slim
+++ b/app/views/form_award_eligibilities/basic_questions/_years_operating.html.slim
@@ -1,7 +1,5 @@
 .question-body
   p.question-context
     = @eligibility.class.hint(question)
-  legend.govuk-fieldset__legend
-    = f.label @eligibility.class.label(step).html_safe, class: 'govuk-label govuk-label--l', tag: 'h2'
-  = f.input :years_operating, as: :numeric, input_html: { class: 'tiny' }, label: false
+  = f.input :years_operating, as: :numeric, wrapper: :numeric, label: @eligibility.class.label(step).html_safe, input_html: { class: 'tiny' }, label_html: { class: 'govuk-label govuk-label--l' }
   span.clear

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -73,7 +73,7 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <span class="govuk-header__link govuk-header__link--service-name qavs-service-name">
+          <span class="govuk-header__link--service-name qavs-service-name">
             Queen's Award for Voluntary Service
           </span>
           <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">Menu</button>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -102,6 +102,19 @@ SimpleForm.setup do |config|
     end
   end
 
+  config.wrappers :numeric, class: 'govuk-form-group', error_class: "govuk-form-group--error" do |b|
+    b.wrapper tag: :fieldset, class: 'govuk-fieldset' do |bb|
+      bb.use :html5
+      bb.optional :readonly
+
+      bb.use :label, wrap_with: { tag: :legend, class: 'govuk-fieldset__legend' }, tag: :h2, class: 'govuk-label govuk-label--l'
+
+      bb.use :error, wrap_with: { class: 'govuk-error-message' }
+      bb.use :hint, wrap_with: { class: 'govuk-hint' }
+      bb.use :input, class: 'govuk-input'
+    end
+  end
+
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default
 
@@ -184,6 +197,7 @@ SimpleForm.setup do |config|
     boolean: :checkbox,
     radio_buttons: :radio_buttons,
     select: :select,
+    numeric: :numeric,
     text: :textarea
   }
 


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1yVVUHchyKLZkxhzB3ZzLU4JR0jxN3Vdw/edit#gid=1086836074
https://app.asana.com/0/1200175839265057/1201148206487248
Following feedback from an accessibility audit, this PR further improves accessibility.
- removes link style from page header to remove hover effect for non-existent link
- adds legend to years_operating eligibility question by adding a custom wrapper in the simple form confi
<img width="683" alt="Screenshot 2021-11-15 at 14 02 57" src="https://user-images.githubusercontent.com/65811538/142171666-9daf2512-833b-468b-8d86-71012b9ede1b.png">
- adds breadcrumb to edit group leader page
<img width="709" alt="Screenshot 2021-11-15 at 14 11 50" src="https://user-images.githubusercontent.com/65811538/142171818-8197a686-ca31-4f2d-8de6-f78aa722e12a.png">

