### PR TITLE
🔧   corrects sub group

### DIFF
--- a/app/views/admin/form_answers/_applicant_details.html.slim
+++ b/app/views/admin/form_answers/_applicant_details.html.slim
@@ -1,5 +1,0 @@
-.well.section-applicant-details
-  - if @form_answer.urn.present?
-    h1.govuk-heading-xl
-      = @form_answer.urn
-  h2.govuk-heading-l = @form_answer.company_name

--- a/app/views/admin/form_answers/_nomination_details.html.slim
+++ b/app/views/admin/form_answers/_nomination_details.html.slim
@@ -14,7 +14,7 @@ p.govuk-body
     strong
       | National assessor sub-group
     br
-    | Sub-group 1
+    = @form_answer.sub_group.try(:text) || "Not assigned"
   p.govuk-body
     strong
       | Lord Lieutenancy office


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1201387817745567
The form_answer/show view is always showing Sub Group 1 as this has not yet been implemented to read from the form_answer attribute. This PR corrects this and adds 'Not assigned' when the sub group does not exist.

Also removes an unused partial view as part of ongoing cleanup.