### PR TITLE
🐛  assessor testing feedback 

### DIFF
--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -56,5 +56,3 @@ $todo-black: #333;
 .govuk-notification-banner__heading {
   max-width: 700px
 }
-
-

--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -56,3 +56,7 @@ $todo-black: #333;
 .govuk-notification-banner__heading {
   max-width: 700px
 }
+
+.govuk-back-link {
+  color: #1d70b8 !important
+}

--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -57,6 +57,4 @@ $todo-black: #333;
   max-width: 700px
 }
 
-.govuk-back-link {
-  color: #1d70b8 !important
-}
+

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1329,3 +1329,13 @@ fieldset.account-contact-preferences-other-ops {
 .back-link {
   color: #1d70b8 !important
 }
+
+.pagination {
+  .as-button {
+    color: white !important;
+
+    &:focus {
+      color: black !important;
+    }
+  }
+}

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1,7 +1,7 @@
 $black-true: #000;
 
 legend {
- 
+
 
   &.light {
     font-weight: 400;
@@ -1324,4 +1324,8 @@ fieldset.account-contact-preferences-other-ops {
     @include core-19;
     margin-bottom: 0;
   }
+}
+
+.back-link {
+  color: #1d70b8 !important
 }

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -642,6 +642,24 @@ header.page-header aside .inner {
     margin-bottom: 10px;
   }
 
+  .step-complete-assessment {
+    margin-top: 25px;
+    margin-bottom: 25px;
+
+    .govuk-button {
+      color: white !important;
+      font-size: 1em;
+
+      &:focus {
+        color: black !important;
+      }
+
+      &:hover {
+        color: white !important;
+      }
+    }
+  }
+
   .sidebar-helpline {
     @include core-16;
     padding: 25px 0;

--- a/app/views/assessor/form_answers/_edit_nomination_links.html.slim
+++ b/app/views/assessor/form_answers/_edit_nomination_links.html.slim
@@ -1,1 +1,10 @@
-= link_to 'View nomination and local assessment form', [:edit, namespace_name, @form_answer], class: "govuk-button"
+.govuk-button-group
+  = link_to 'View nomination form',
+    [:edit, namespace_name, @form_answer],
+    class: "govuk-button",
+    role: "button"
+
+  = link_to 'View local assessment form',
+    [:edit, namespace_name, @form_answer, anchor: "local-assessment-form"],
+    class: "govuk-button",
+    role: "button"

--- a/app/views/assessor/form_answers/edit.html.slim
+++ b/app/views/assessor/form_answers/edit.html.slim
@@ -1,7 +1,7 @@
 - provide(:page_wrapper_class, "page-award-form")
 
 - content_for :before_main_content do
-  = link_to "Go back to #{@form_answer.nominee_name} nomination summary page", assessor_form_answer_path(@form_answer), class: "govuk-back-link"
+  = link_to "Go back to #{@form_answer.nominee_name} nomination summary page", assessor_form_answer_path(@form_answer), class: "govuk-back-link back-link"
 
 form.qae-form.award-form data-autosave-url="#" action="#" method="POST" data-attachments-url=attachments_url(@form_answer) novalidate=true
 

--- a/app/views/lieutenant/dashboard/index.html.slim
+++ b/app/views/lieutenant/dashboard/index.html.slim
@@ -19,7 +19,7 @@
                   rel: "noreferrer noopener",
                   target: :_blank
       hr.govuk-section-break.govuk-section-break--m
-      p.govuk-body Each assessment has to be submitted using an online form that is linked to each nomination. However, you may find it useful to work using Word format of the local assessment form, which you can use on your digital device offline or in printed format.
+      p.govuk-body Each assessment report has to be submitted using an online form that is linked to that group. However, you may prefer to download a Word version of the form, which you can print off or save, and use as a template while you carry out your assessment. Once your assessment is complete, you can then copy and paste the final answers into the online form.
       .govuk-body
         = link_to "Download QAVS local assessment form 2022 (Word)",
                   "https://storage.googleapis.com/lord-lieutenant-guidance/QAVS%20local%20assessment%20form%202022%20download.docx",

--- a/app/views/lieutenant/form_answers/edit.html.slim
+++ b/app/views/lieutenant/form_answers/edit.html.slim
@@ -1,7 +1,7 @@
 - provide(:page_wrapper_class, "page-award-form")
 
 - content_for :before_main_content do
-  = link_to "Go back to #{@form_answer.nominee_name} nomination summary page", lieutenant_form_answer_path(@form_answer), class: "govuk-back-link"
+  = link_to "Go back to #{@form_answer.nominee_name} nomination summary page", lieutenant_form_answer_path(@form_answer), class: "govuk-back-link back-link"
 
 form.qae-form.award-form data-autosave-url=save_lieutenant_form_answer_url(@form_answer) action=save_lieutenant_form_answer_url(@form_answer, next_step: next_step(@form, params[:step]), current_step: params[:step]) method="POST" data-attachments-url=attachments_url(@form_answer) novalidate=true
 

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -46,6 +46,10 @@ footer
               - else
                 = "View #{next_step.title(:other).humanize.downcase}"
 
+      - if current_assessor
+        li.step-complete-assessment
+          = button_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button", method: :get
+
       - else
         - if step.submit && (current_form_is_editable? || (current_lieutenant && step.local_assessment?) || (admin? && !admin_in_read_only_mode? && !step.local_assessment?)) && policy(@form_answer).submit?
           li.submit.qae-form

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -48,7 +48,7 @@ footer
 
       - if current_assessor && step.local_assessment?
         li.step-complete-assessment
-          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button as-button", role: "button"
+          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button as-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
 
       - else
         - if step.submit && (current_form_is_editable? || (current_lieutenant && step.local_assessment?) || (admin? && !admin_in_read_only_mode? && !step.local_assessment?)) && policy(@form_answer).submit?

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -48,7 +48,7 @@ footer
 
       - if current_assessor && step.local_assessment?
         li.step-complete-assessment
-          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button as-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
+          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button as-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion"}
 
       - else
         - if step.submit && (current_form_is_editable? || (current_lieutenant && step.local_assessment?) || (admin? && !admin_in_read_only_mode? && !step.local_assessment?)) && policy(@form_answer).submit?

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -46,9 +46,9 @@ footer
               - else
                 = "View #{next_step.title(:other).humanize.downcase}"
 
-      - if current_assessor
+      - if current_assessor && step.local_assessment?
         li.step-complete-assessment
-          = button_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button", method: :get
+          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer), class: "govuk-button as-button", role: "button"
 
       - else
         - if step.submit && (current_form_is_editable? || (current_lieutenant && step.local_assessment?) || (admin? && !admin_in_read_only_mode? && !step.local_assessment?)) && policy(@form_answer).submit?

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -51,7 +51,7 @@
     - if current_assessor
       li.step-complete-assessment
         = link_to "Complete national assessment", assessor_form_answer_path(@form_answer), class: "govuk-button", role: "button"
-    li.divider
+      li.divider
     li.sidebar-helpline.govuk-body
       ' Need help? Call us on
       br

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -50,7 +50,7 @@
     li.divider
     - if current_assessor
       li.step-complete-assessment
-        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer), class: "govuk-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
+        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
       li.divider
     li.sidebar-helpline.govuk-body
       ' Need help? Call us on

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -48,6 +48,10 @@
         - else
           = link_to "Download your nomination (PDF)", nomination_pdf_url(@form_answer), class: "download-pdf-link govuk-link"
     li.divider
+    - if current_assessor
+      li.step-complete-assessment
+        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer), class: "govuk-button", role: "button"
+    li.divider
     li.sidebar-helpline.govuk-body
       ' Need help? Call us on
       br

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -56,7 +56,7 @@
       ' Alternatively, email us at
       = link_to "queensaward@dcms.gov.uk", "mailto:queensaward@dcms.gov.uk"
 
-    - if submission_deadline && submission_deadline.trigger_at && !lieutenant_nomination?
+    - if submission_deadline && submission_deadline.trigger_at && !lieutenant_nomination? && !current_assessor
       .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
         .govuk-notification-banner__header
           h2.govuk-notification-banner__title#govuk-notification-banner-title

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -50,7 +50,7 @@
     li.divider
     - if current_assessor
       li.step-complete-assessment
-        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer), class: "govuk-button", role: "button"
+        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer), class: "govuk-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
       li.divider
     li.sidebar-helpline.govuk-body
       ' Need help? Call us on


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1201513040984351/f
https://docs.google.com/spreadsheets/d/1pcgZUhKP8lRCy-b4EBPzeJCrkhRU77jGbMuHX77r2QM/edit#gid=1057492860

ID 2: hides the submission deadline box for assessors

ID 3: adds sidebar button to return assessors to summary page
<img width="1114" alt="Screenshot 2021-12-14 at 21 18 19" src="https://user-images.githubusercontent.com/65811538/146084118-bd92484c-4f34-49cd-82ff-d7b276610431.png">

ID 3: adds button to local assessment footer
<img width="888" alt="Screenshot 2021-12-14 at 21 42 55" src="https://user-images.githubusercontent.com/65811538/146092475-6d058423-e178-4905-b0b4-ab82821478a7.png">

ID 4: changes back link colours on the nomination and local assessment form to blue to make more prominent
![Screenshot 2021-12-14 at 14 30 45](https://user-images.githubusercontent.com/65811538/146021152-132c1e87-8fca-4e90-8bee-d729b9119fc9.png)

ID 6: splits the 'View Nomination and Local Assessment form' button into 2 separate buttons
![Screenshot 2021-12-14 at 14 50 42](https://user-images.githubusercontent.com/65811538/146021412-c520dd67-0e05-43e7-99b7-5ecd670e6107.png)

https://app.asana.com/0/1199154381249427/1201513040984363
copy change on lieutenants dashboard for paragraph beginning 'Each assessment'
![Screenshot 2021-12-14 at 14 47 04](https://user-images.githubusercontent.com/65811538/146021539-7da77165-7edf-45c2-acdb-41e3a9007bde.png)

