### PR TITLE
Autofocus on national assessment accordion item

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -328,3 +328,32 @@ $('.qae-form').find('input[type="number"]').each(function() {
   $(this).attr('pattern', '[0-9]*');
   $(this).attr('inputmode', 'decimal');
 });
+
+if ($('.submitted-view').length > 0) {
+  var hash = window.location.hash;
+
+  if (hash) {
+    var heading = $(hash);
+
+    if (heading) {
+      var waitForAccordionAndClickIt = function() {
+        var button = heading.find('button.govuk-accordion__section-button');
+
+        if (button.length > 0) {
+          setTimeout(function() {
+            if (button.first().attr('aria-expanded') !== 'true') {
+              button.first().trigger('click');
+            }
+
+            button.first().focus();
+          }, 1000);
+          return;
+        }
+
+        setTimeout(waitForAccordionAndClickIt, 2000);
+      }
+
+      waitForAccordionAndClickIt();
+    }
+  }
+}

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -48,7 +48,7 @@ footer
 
       - if current_assessor && step.local_assessment?
         li.step-complete-assessment
-          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button as-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion"}
+          = link_to "Go to the national assessment form", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button as-button"
 
       - else
         - if step.submit && (current_form_is_editable? || (current_lieutenant && step.local_assessment?) || (admin? && !admin_in_read_only_mode? && !step.local_assessment?)) && policy(@form_answer).submit?

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -50,7 +50,7 @@
     li.divider
     - if current_assessor
       li.step-complete-assessment
-        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button", role: "button", data: { toggle: "collapse", parent: "govuk-accordion" }
+        = link_to "Complete national assessment", assessor_form_answer_path(@form_answer, anchor: "assessment-assessor-#{current_assessor.id}"), class: "govuk-button"
       li.divider
     li.sidebar-helpline.govuk-body
       ' Need help? Call us on


### PR DESCRIPTION
This PR autofocuses on national assessment accordion item when assessors click on 2 different buttons when viewing assessment forms.

Card: https://app.asana.com/0/1200061634447616/1201514725436936