### PR TITLE
add alternative nomination view for national assessors

### DIFF
--- a/app/views/assessor/form_answers/_question.html.slim
+++ b/app/views/assessor/form_answers/_question.html.slim
@@ -1,0 +1,45 @@
+- if question.header
+  h2.govuk-heading-l
+    = question.header
+fieldset class=question.fieldset_classes data=question.fieldset_data_hash
+  = condition_divs question do
+    .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+      - ref = question.ref ? question.ref : question.sub_ref
+      - if question.title != "" || question.show_ref_always.present?
+        - if question.label_as_legend?
+          legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              - font_size = question.delegate_obj.is_a?(QAEFormBuilder::HeaderQuestion) ? "govuk-!-font-size-36" : "govuk-!-font-size-24"
+              span class="govuk-body #{ font_size } govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
+
+            = render "qae_form/question_sub_title", question: question
+
+        - else
+          legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+          label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
+
+            = render "qae_form/question_sub_title", question: question
+
+      - else
+        - if question.ref || question.sub_ref
+          .if-js-hide
+            label.govuk-label for="q_#{question.key}" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.visuallyhidden
+                  = ref.to_s
+                span.todo
+                  = ref.to_s
+
+      = render "assessor/form_answers/questions/#{question.delegate_obj.class.name.demodulize.underscore}", question: question, answers: answers, attachments: attachments

--- a/app/views/assessor/form_answers/questions/_address_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_address_question.html.slim
@@ -1,0 +1,69 @@
+div role="group" id="q_#{question.key}"
+  - question.rendering_sub_fields.each do |sub_field_block|
+    - sub_field_key = sub_field_block[0]
+    - sub_field_title = sub_field_block[1]
+
+    - case sub_field_key
+    - when :building
+      .govuk-form-group
+        label.govuk-label for="q_#{question.key}_line_1"
+          ' Building
+        span.govuk-error-message
+          span.govuk-visually-hidden
+            | Error:
+          - if @form_answer.validator_errors&.dig(question.hash_key(suffix: "building"))
+            = @form_answer.validator_errors[question.hash_key(suffix: "building")]
+
+        input.govuk-input.govuk-input--width-10.js-trigger-autosave.required type="text" name=question.input_name(suffix: 'building') value=question.input_value(suffix: 'building') autocomplete="off"  id="q_#{question.key}_line_1" disabled="disabled"
+      .govuk-form-group
+        label.govuk-label for="q_#{question.key}_line_2"
+          ' Street
+        span.govuk-error-message
+          span.govuk-visually-hidden
+            | Error:
+          - if @form_answer.validator_errors&.dig(question.hash_key(suffix: "street"))
+            = @form_answer.validator_errors[question.hash_key(suffix: "street")]
+        input.govuk-input.govuk-input--width-10.js-trigger-autosave type="text" name=question.input_name(suffix: 'street') value=question.input_value(suffix: 'street') autocomplete="off" id="q_#{question.key}_line_2" disabled="disabled"
+    - when :country
+      .govuk-form-group
+        label.govuk-label for="#{question.key}_country"
+          ' Country
+        = country_select(question.step.form.form_name, "#{question.key}_country", {priority_countries: ["GB", "US"], selected: question.input_value(suffix: 'country')}, { disabled: "disabled", name: question.input_name(suffix: 'country'), class: 'js-trigger-autosave required govuk-select' })
+        span.govuk-error-message
+          span.govuk-visually-hidden
+            | Error:
+          - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
+            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        .clear
+
+    - when :county
+      .govuk-form-group
+        label.govuk-label id="#{question.key}_region_label" for="#{question.key}_county"
+          ' County
+        span.govuk-error-message
+          span.govuk-visually-hidden
+            | Error:
+          - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
+            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        .clear
+
+        - if question.county_context.present?
+          .question-context[id="#{question.key}_county_hint"]
+            == question.county_context
+
+        = select_tag("#{question.key}_county", options_for_select(question.counties, question.input_value(suffix: "county")), { name: question.input_name(suffix: 'county'), class: "js-trigger-autosave required custom-select govuk-select", include_blank: true, disabled: "disabled" })
+
+    - else
+      .govuk-form-group
+        label.govuk-label for=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key)
+          = sub_field_title
+        span.govuk-error-message
+          span.govuk-visually-hidden
+            | Error:
+          - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
+            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        .clear
+
+        - klass = "#{sub_field_title.parameterize == 'postcode' ? 'govuk-input--width-10' : 'govuk-input--width-20'}"
+        - klass <<(QAEFormBuilder::AddressQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
+        input.govuk-input.js-trigger-autosave class=klass type="text" id=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key) name=question.input_name(suffix: sub_field_key) autocomplete="off" disabled="disabled"

--- a/app/views/assessor/form_answers/questions/_assessor_details_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_assessor_details_question.html.slim
@@ -1,0 +1,17 @@
+.govuk-fieldset role="group" id="q_#{question.key}"
+  - question.rendering_sub_fields.each do |sub_field_block|
+    - sub_field_key = sub_field_block[0]
+    - sub_field_title = sub_field_block[1]
+    .govuk-form-group
+      label.govuk-label for=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key)
+        = sub_field_title
+      span.govuk-error-message
+        span.govuk-visually-hidden
+          | Error:
+        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
+          =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+      .clear
+
+      - klass = "#{sub_field_title.parameterize == "phone-number-optional" ? "govuk-input--width-10" : "govuk-input--width-20"}"
+      - klass <<(QAEFormBuilder::AssessorDetailsQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
+      input.govuk-input.js-trigger-autosave class=klass type="text" id=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key) name=question.input_name(suffix: sub_field_key) autocomplete="off" disabled="disabled"

--- a/app/views/assessor/form_answers/questions/_ceremonial_county_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_ceremonial_county_question.html.slim
@@ -1,0 +1,4 @@
+select.govuk-select.js-trigger-autosave name=question.input_name disabled="disabled" id="q_#{question.key}"
+  - question.options.each do |option|
+    option value="#{option.value}" selected=((question.input_value || '').to_s == option.value.to_s)
+      = option.text

--- a/app/views/assessor/form_answers/questions/_checkbox_seria_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_checkbox_seria_question.html.slim
@@ -1,0 +1,13 @@
+input name="form[#{question.key}][array]" value="true" type="hidden" disabled="disabled"
+
+- values = question.entities
+
+.govuk-checkboxes data-module="govuk-checkboxes"
+  - question.check_options.each_with_index do |check_option, placement|
+    - value_selected = values.is_a?(Array) && values.detect { |el| el['type'].to_s == check_option[0].to_s }
+
+    .govuk-checkboxes__item.qae-form-checkbox-seria-question-item
+      input.govuk-checkboxes__input.js-trigger-autosave type="checkbox" id=question.input_name(suffix: "type_#{placement}") name="#{question.input_name}[#{placement}][type]" value="#{check_option[0]}" checked=('checked' if value_selected) disabled="disabled"
+
+      label.govuk-label.govuk-checkboxes__label for=question.input_name(suffix: "type_#{placement}")
+        = check_option[1].html_safe

--- a/app/views/assessor/form_answers/questions/_confirm_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_confirm_question.html.slim
@@ -1,0 +1,9 @@
+.selectable-confirm-wrapper
+  .govuk-checkboxes data-module="govuk-checkboxes"
+    .govuk-checkboxes__item
+      input.js-trigger-autosave.govuk-checkboxes__input type="checkbox" name=question.input_name id="q_#{question.key}" checked=!!question.input_value disabled="disabled"
+      label.govuk-label.govuk-checkboxes__label for="q_#{question.key}"
+        - if question.key == :shortlisted_case_confirmation
+          == interpolate_deadlines question.text
+        - elsif question.text
+          == question.text

--- a/app/views/assessor/form_answers/questions/_dropdown_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_dropdown_question.html.slim
@@ -1,0 +1,4 @@
+select.govuk-select.js-trigger-autosave name=question.input_name disabled="disabled" id="q_#{question.key}"
+  - question.options.each do |option|
+    option value="#{option.value}" selected=((question.input_value || '').to_s == option.value.to_s)
+      = option.text

--- a/app/views/assessor/form_answers/questions/_header_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_header_question.html.slim
@@ -1,0 +1,1 @@
+= render "qae_form/header_question", question: 'question', answers: answers, attachments: attachments

--- a/app/views/assessor/form_answers/questions/_number_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_number_question.html.slim
@@ -1,0 +1,3 @@
+input.js-trigger-autosave class="govuk-input #{question.style.presence || 'govuk-input--width-10'}" type="#{question.type.presence || 'text'}" min=question.min max=question.max name=question.input_name value=question.input_value autocomplete="off" id="q_#{question.key}" disabled="disabled"
+-if question.unit
+  = question.unit

--- a/app/views/assessor/form_answers/questions/_options_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_options_question.html.slim
@@ -1,0 +1,8 @@
+.govuk-radios.govuk-radios--inline
+  - for answer in question.options do
+    .govuk-radios__item
+      input.js-trigger-autosave.govuk-radios__input type="radio" id="#{question.input_name}_#{answer.value.to_s.parameterize}" name=question.input_name value=answer.value checked=(answer.value.to_s == (question.input_value || '').to_s || (question.input_value.blank? && question.default_option.to_s == answer.value.to_s)) aria-describedby="#{question.input_name}_#{answer.value.to_s.parameterize}_hint" disabled="disabled"
+      label.govuk-label.govuk-radios__label for="#{question.input_name}_#{answer.value.to_s.parameterize}"
+        = answer.text.html_safe
+      span.question-context id="#{question.input_name}_#{answer.value.to_s.parameterize}_hint"
+        p = question.context_for_options[answer.value].try(:html_safe)

--- a/app/views/assessor/form_answers/questions/_supporters_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_supporters_question.html.slim
@@ -1,0 +1,16 @@
+input name="form[#{question.key}][array]" value="true" type="hidden" disabled="disabled"
+ul.list-add.supporters-list data-need-to-clear-example=true data-add-limit=question.limit data-attachments-url=(users_form_answer_support_letter_attachments_path(@form_answer)) data-example-has-file-field=true
+  = render 'qae_form/supporter_fields_placeholder', question: question
+  - if question.entities.present?
+    - if question.entities.count < question.default.to_i
+      - question.entities.each_with_index do |supporter, index|
+        = render 'qae_form/supporter_fields', question: question, supporter: supporter, index: index
+    - else
+      - question.entities.each_with_index do |supporter, index|
+        = render 'qae_form/supporter_fields', question: question, supporter: supporter, index: index
+  - else
+    - (0...question.default.to_i).each do |index|
+      = render 'qae_form/supporter_fields', question: question, supporter: {}, index: index
+
+a.govuk-button.govuk-button--secondary.button-add.js-button-add href="#" disabled="disabled"
+  | Add another letter of support

--- a/app/views/assessor/form_answers/questions/_text_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_text_question.html.slim
@@ -1,0 +1,1 @@
+input class="govuk-input js-trigger-autosave #{ question.style.presence || 'govuk-input--width-10' }" type="#{ question.type.presence || 'text' }" name=question.input_name value=question.input_value autocomplete="off" id="q_#{question.key}" disabled="disabled"

--- a/app/views/assessor/form_answers/questions/_textarea_question.html.slim
+++ b/app/views/assessor/form_answers/questions/_textarea_question.html.slim
@@ -1,0 +1,8 @@
+.if-no-js-hide
+  .js-ckeditor-spinner-block
+    = image_tag "textarea_spinner.gif", alt: ""
+    span.govuk-body
+      | Loading Editor ...
+
+textarea.js-trigger-autosave.js-ckeditor.govuk-textarea rows=question.rows  name=question.input_name id="q_#{question.key}" disabled="disabled"
+  = question.input_value

--- a/app/views/qae_form/_step.html.slim
+++ b/app/views/qae_form/_step.html.slim
@@ -9,10 +9,11 @@
     - if step.context
       == step.context
 
-    - if step.notice
+    - if step.notice && !current_assessor
       .govuk-inset-text
         == format_submit_notice(step.notice)
-    = render partial: "qae_form/question", collection: step.questions, locals: { answers: answers, attachments: attachments }
+    - question_partial = current_assessor ? "assessor/form_answers/question" : "qae_form/question"
+    = render partial: question_partial, collection: step.questions, locals: { answers: answers, attachments: attachments }
     - if step.submit
       = render partial: "qae_form/step_submit", object: step.submit, as: 'submit'
 

--- a/app/views/qae_form/_step_submit.html.slim
+++ b/app/views/qae_form/_step_submit.html.slim
@@ -3,7 +3,7 @@
     p
       = render "qae_form/pdf_link"
 
-  - if submit.notice && (!current_lieutenant || current_lieutenant.role.advanced?)
+  - if submit.notice && (!current_lieutenant || current_lieutenant.role.advanced?) && (!current_assessor)
     .govuk-inset-text
       == format_submit_notice(submit.notice)
   - if submit.alternative_notices && current_lieutenant && current_lieutenant.role.regular?


### PR DESCRIPTION
https://app.asana.com/0/1200175839265057/1201559758877458/f

Everything is basically the same, cleaned up some conditions for disabled fields.

Remove help copy/notice at the beginning of the form
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/332810/148777585-f5de2171-41b0-4d1b-a8d1-6b8cd00d4cf8.png">

Remove word limit 
<img width="704" alt="image" src="https://user-images.githubusercontent.com/332810/148777500-e960baca-a9f9-45c7-ab49-d7db2a8703b9.png">

Remove help copy about submission at the end of the form
<img width="831" alt="image" src="https://user-images.githubusercontent.com/332810/148777727-6b4f9fd5-4fa3-43d0-9070-a51172c63d27.png">
