### PR TITLE
Excludes fields from address question validations

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -66,7 +66,7 @@ window.FormValidation =
     date.diff(expected, "days")
 
   validateSingleQuestion: (question) ->
-    if question.find("input").hasClass("not-required")
+    if question.find("input, select").hasClass("not-required")
       return true
     else
       if @isSelectQuestion(question)

--- a/app/forms/award_years/v2022/qavs/qavs_step5.rb
+++ b/app/forms/award_years/v2022/qavs/qavs_step5.rb
@@ -61,7 +61,7 @@ class AwardYears::V2022::QAEForms
             { building: "Number or name of building" },
             { street: "Street" },
             { city: "Village or town" },
-            { county: "County" },
+            { county: "County", ignore_validation: true },
             { postcode: "Postcode" },
             { london_borough: "London borough (if applicable)", ignore_validation: true }
           ])

--- a/app/forms/qae_form_builder/address_question.rb
+++ b/app/forms/qae_form_builder/address_question.rb
@@ -26,7 +26,9 @@ class QAEFormBuilder
 
     def required_sub_fields
       if sub_fields.present?
-        sub_fields
+        sub_fields.reject do |f|
+          f[:ignore_validation]
+        end
       else
         [
           { building: "Building" },
@@ -42,7 +44,7 @@ class QAEFormBuilder
       # We are rejecting :street, because :building and :street
       # are rendering together in same block
       # and the :building is the first one
-      required_sub_fields.reject do |f|
+      sub_fields.reject do |f|
         f.keys.include?(:street)
       end.map do |f|
         [f.keys.first, f.values.first]

--- a/app/views/qae_form/_address_question.html.slim
+++ b/app/views/qae_form/_address_question.html.slim
@@ -51,7 +51,9 @@ div role="group" id="q_#{question.key}"
           .question-context[id="#{question.key}_county_hint"]
             == question.county_context
 
-        = select_tag("#{question.key}_county", options_for_select(question.counties, question.input_value(suffix: "county")), possible_read_only_ops(question.step.opts[:id]).merge({name: question.input_name(suffix: 'county'), class: "js-trigger-autosave required custom-select govuk-select", include_blank: true}))
+        - klass = "js-trigger-autosave custom-select govuk-select"
+        - klass <<(question.required_sub_fields.any? {|f| f[:county]} ? " required" : " not-required")
+        = select_tag("#{question.key}_county", options_for_select(question.counties, question.input_value(suffix: "county")), possible_read_only_ops(question.step.opts[:id]).merge({name: question.input_name(suffix: 'county'), class: klass, include_blank: true}))
 
     - else
       .govuk-form-group


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1201672148259126

- Removes the required field for the county dropdown in the local assessment form. This amends the required_sub_fields method in the address_builder to reject fields when the attribute ignore_validations is present. The 'not-required' attribute can then be added when the sub_field is missing from the required_sub_fields array. This also adds select fields when checking javascript validations.