### PR TITLE
Updates eligibility question for a typo

### DIFF
--- a/app/models/eligibility/basic.rb
+++ b/app/models/eligibility/basic.rb
@@ -29,7 +29,7 @@ class Eligibility::Basic < Eligibility
 
   property :years_operating,
             positive_integer: true,
-            label: "How long has the group been operating? (it must have been operating for be at least 3 years before nomination)",
+            label: "How long has the group been operating? (it must have been operating for at least 3 years before nomination)",
             accept: :more_than_two
 
   property :current_holder,

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -17,8 +17,8 @@ describe "Eligibility forms" do
 
       click_button("Start eligibility questionnaire")
       form_choice(["Yes", "Yes", "Yes", "No", "No"])
-      expect(page).to have_content('How long has the group been operating? (it must have been operating for be at least 3 years before nomination)')
-      fill_in("How long has the group been operating? (it must have been operating for be at least 3 years before nomination)", with: 3)
+      expect(page).to have_content('How long has the group been operating? (it must have been operating for at least 3 years before nomination)')
+      fill_in("How long has the group been operating? (it must have been operating for at least 3 years before nomination)", with: 3)
       click_button "Continue"
       form_choice("No")
       expect(page).to have_content("You are eligible to begin your nomination")


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1201770785534673

This commit fixes a typo on the eligibility question "How long has the group been operating? (it must have been operating for at least 3 years before nomination)"