### PR TITLE
[QAVS0222] - Eligibility questions copy changes

### DIFF
--- a/app/helpers/eligibility_helper.rb
+++ b/app/helpers/eligibility_helper.rb
@@ -6,7 +6,7 @@ module EligibilityHelper
   def eligibility_volunteer_majority_question_ops
     [
       ['Yes', 'true'],
-      ['No (permitted in exceptional circumstances)', 'false'],
+      ['No', 'false'],
       ["Don't know", 'na']
     ]
   end
@@ -16,7 +16,7 @@ module EligibilityHelper
     when 'true'
       'Yes'
     when 'false'
-      'No (permitted in exceptional circumstances)'
+      'No'
     when 'na'
       "Don't know"
     end

--- a/app/models/eligibility/basic.rb
+++ b/app/models/eligibility/basic.rb
@@ -9,7 +9,7 @@ class Eligibility::Basic < Eligibility
 
   property :years_operating,
            positive_integer: true,
-           label: "How long has the group been operating?",
+           label: "How many years has the group been in operation?",
            hint: "The group must have been operating for at least 3 years before nomination.",
            accept: :more_than_two
 

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -17,8 +17,8 @@ describe "Eligibility forms" do
 
       click_button("Start eligibility questionnaire")
       form_choice(%w[Yes])
-      expect(page).to have_content("How long has the group been operating?")
-      fill_in("How long has the group been operating?", with: 3)
+      expect(page).to have_content("How many years has the group been in operation?")
+      fill_in("How many years has the group been in operation?", with: 3)
       click_button "Continue"
       form_choice(%w[Yes Yes No Yes No No No])
       expect(page).to have_content("Thank you. Based on your answers, the group meets the basic eligibility citeria. You can proceed with nominating.")


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1201929204570014
For the question 'Are the majority of the group volunteers?', under No, please can we remove 'permitted in exceptional circumstances'.

https://app.asana.com/0/1199154381249427/1201929204570016
Instead of saying 'how long has the group been operating' we should ask 'how many years has the group been in operation' so they know they just have to enter a number.