### PR TITLE
[QAVS0422] Reinstates the award year dropdown on the Nominations dashboard

### DIFF
--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -35,8 +35,8 @@ class Assessor::FormAnswersController < Assessor::BaseController
     search_params = save_or_load_search!
 
     scope = current_assessor.applications_scope(
-      @award_year
-    )
+      params[:year].to_s == "all_years" ? nil : @award_year
+    ).eligible_for_assessor
 
     if search_params[:query].blank? && category_picker.show_award_tabs_for_assessor?
       scope = scope.where(award_type: category_picker.current_award_type)

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -97,7 +97,7 @@ module FormAnswerMixin
 
     if params[:search] && params[:search][:search_filter] != FormAnswerSearch.default_search[:search_filter]
       search = NominationSearch.create(serialized_query: params[:search].to_json)
-      redirect_to [namespace_name, :form_answers, search_id: search.id]
+      redirect_to [namespace_name, :form_answers, search_id: search.id, year: params[:year]]
     end
 
     if params[:search_id]

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -42,7 +42,11 @@ class Assessor < ApplicationRecord
   end
 
   def applications_scope(award_year)
-    award_year.form_answers.where(state: FormAnswerStateMachine::ASSESSOR_VISIBLE_STATES, sub_group: sub_group)
+    if award_year
+      award_year.form_answers
+    else
+      FormAnswer.all
+    end.where(state: FormAnswerStateMachine::ASSESSOR_VISIBLE_STATES, sub_group: sub_group)
   end
 
   def full_name

--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -99,7 +99,7 @@ class AwardYear < ApplicationRecord
 
   def self.admin_switch
     output = {}
-    year0 = 2016
+    year0 = 2022
     (year0..(current.year + 3)).each do |year|
       output[year] = "#{year - 1} - #{year}"
     end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -83,6 +83,7 @@ class FormAnswer < ApplicationRecord
     scope :not_positive, -> { where(state: FormAnswerStateMachine::NOT_POSITIVE_STATES) }
     scope :in_progress, -> { where(state: ["eligibility_in_progress", "application_in_progress"]) }
     scope :eligible_for_lieutenant, -> { where(state: FormAnswerStatus::LieutenantFilter::OPTIONS.keys) }
+    scope :eligible_for_assessor, -> { where(state: FormAnswerStatus::AssessorFilter::OPTIONS.keys) }
     scope :lieutenancy_assigned, -> { where.not(ceremonial_county_id: nil) }
 
     scope :past, -> {

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -21,7 +21,7 @@ h1.govuk-heading-xl
                                                          sub_options: FormAnswerStatus::AdminFilter.collection('sub')
 
   .govuk-grid-row
-    - address_county_options = @award_year.year == 2022 ? FormAnswerStatus::AdminFilter.collection('group address county 2022') : FormAnswerStatus::AdminFilter.collection('group address county')
+    - address_county_options = @award_year.year <= 2022 ? FormAnswerStatus::AdminFilter.collection('group address county 2022') : FormAnswerStatus::AdminFilter.collection('group address county')
     = render "admin/form_answers/nomination_answer_filters", f: f,
                                                              activity_options: FormAnswerStatus::AdminFilter.collection('activity type'),
                                                              assigned_county_options: FormAnswerStatus::AdminFilter.collection('assigned county'),

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -3,10 +3,14 @@
 h1.govuk-heading-xl
   | Nominations
 
-= simple_form_for @search, url: admin_form_answers_path, method: :post, as: :search, html: { class: 'search-form'} do |f|
+= simple_form_for @search, url: admin_form_answers_path(year: params[:year]), method: :post, as: :search, html: { class: 'search-form'} do |f|
+  .govuk-grid-row
+    = render "layouts/vertical_admin_award_year"
+
   .govuk-grid-row
     .govuk-grid-column-one-quarter.if-js-hide
       = f.input :year, input_html: { value: params[:year] || @award_year.year }
+
     .govuk-grid-column-one-third
       .form-group.search-input
         = f.input :query, label: 'Search', input_html: { type: "search" }

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -2,12 +2,14 @@
 
 h1.govuk-heading-xl
   | Nominations for your sub-group
-= simple_form_for @search, url: assessor_form_answers_path, method: :post, as: :search do |f|
-  = hidden_field_tag :year, params[:year] || @award_year.year, class: "visuallyhidden"
-  = hidden_field_tag :award_type, params[:award_type], class: "visuallyhidden"
+= simple_form_for @search, url: assessor_form_answers_path(year: params[:year]), method: :post, as: :search do |f|
+  .govuk-grid-row
+    = render "layouts/vertical_admin_award_year"
 
   .govuk-grid-row
     .govuk-grid-column-one-third
+      = hidden_field_tag :year, params[:year] || @award_year.year, class: "visuallyhidden"
+      = hidden_field_tag :award_type, params[:award_type], class: "visuallyhidden"
       = f.input :query, label: 'Search', input_html: { class: "medium", type: "search" }
   .govuk-grid-row
     = render "assessor/form_answers/filters", f: f,

--- a/app/views/layouts/_vertical_admin_award_year.html.slim
+++ b/app/views/layouts/_vertical_admin_award_year.html.slim
@@ -1,9 +1,7 @@
 .govuk-grid-column-one-quarter.applications-filter
   .govuk-form-group
-    label.govuk-label
-      ' Award year
     .dropdown
-      button.dropdown-toggle.govuk-button.govuk-button--secondary aria-expanded="false"
+      button.dropdown-toggle.govuk-button.govuk-button--secondary aria-expanded="false" aria-label='Award Year'
         span class="govuk-visually-hidden"
           | Award year:&nbsp;
         - current_year = params[:year] ? params[:year].to_i : AwardYear.current.year
@@ -12,8 +10,8 @@
         = params[:year].to_s == "all_years" ? "All Years" : current_year_text
       ul.dropdown-menu
         li class="#{'active' if params[:year].to_s == 'all_years'}"
-          = link_to "All Years", url_for(params.permit(:controller, :action).merge(year: :all_years))
+          = link_to "All Years", url_for(params.permit(:controller, :action, :search_id, :year).merge(year: :all_years)), class: "govuk-!-font-size-19 govuk-link--no-underline"
 
         - AwardYear.admin_switch.each do |year, label|
           li class="#{'active' if label == current_year_text}"
-            = link_to label, url_for(params.permit(:controller, :action).merge(year: year))
+            = link_to label, url_for(params.permit(:controller, :action, :search_id, :year).merge(year: year)), class: "govuk-!-font-size-19 govuk-link--no-underline"

--- a/app/views/layouts/_vertical_admin_award_year.html.slim
+++ b/app/views/layouts/_vertical_admin_award_year.html.slim
@@ -9,8 +9,10 @@
 
         = params[:year].to_s == "all_years" ? "All Years" : current_year_text
       ul.dropdown-menu
-        li class="#{'active' if params[:year].to_s == 'all_years'}"
-          = link_to "All Years", url_for(params.permit(:controller, :action, :search_id, :year).merge(year: :all_years)), class: "govuk-!-font-size-19 govuk-link--no-underline"
+        / Commented out option for All Years as this will cause issues with the different county options. Can be uncommented when there is a single county list to use.
+        
+        / li class="#{'active' if params[:year].to_s == 'all_years'}"
+        /   = link_to "All Years", url_for(params.permit(:controller, :action, :search_id, :year).merge(year: :all_years)), class: "govuk-!-font-size-19 govuk-link--no-underline"
 
         - AwardYear.admin_switch.each do |year, label|
           li class="#{'active' if label == current_year_text}"

--- a/app/views/lieutenant/form_answers/index.html.slim
+++ b/app/views/lieutenant/form_answers/index.html.slim
@@ -2,7 +2,10 @@
 
 h1.govuk-heading-xl
   | Nominations for your Lieutenancy
-= simple_form_for @search, url: lieutenant_form_answers_path, method: :post, as: :search do |f|
+= simple_form_for @search, url: lieutenant_form_answers_path(year: params[:year]), method: :post, as: :search do |f|
+  .govuk-grid-row
+    = render "layouts/vertical_admin_award_year"
+
   .govuk-grid-row
     .govuk-grid-column-one-third
       .form-group.search-input


### PR DESCRIPTION
https://app.asana.com/0/home/1200061634431011/1202057858108917

### /form_answer/index

- Passes the year as a params in the search to allow year changes to persist when making filter and search queries.
- Permits :search_id and :year as params to allow queries and filters to persist when changing the year.
- Adds the award year select button above the search bar - this differs to the Asana card as quicker to implement.
- Changes the first year to 2022 to match the data imported from the old QAVS. This will stop users being able to select years prior to 2022 (in case they expect to see old data)
- Comments the option to select All Years. Currently due to having different county lists across years this option will behave unpredictably. Can be reinstated when there is a single county list again.
 
![Screenshot 2022-04-05 at 11 16 18](https://user-images.githubusercontent.com/65811538/161732518-11e0e814-6772-4651-8af1-20a4027ebefc.png)

### Assessors
Amends the scope to allow for` 'all_years'` as an option



