### PR TITLE
Year filter fixes 

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -27,6 +27,8 @@ class Admin::FormAnswersController < Admin::BaseController
   expose(:target_scope) do
     if params[:year].to_s == "all_years"
       FormAnswer.all
+    elsif params[:year]
+      (year = AwardYear.find_by(year: params[:year])) ? year.form_answers : FormAnswer.none
     else
       @award_year.form_answers
     end

--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -23,7 +23,16 @@ class FormAnswerSearch < Search
   end
 
   def filter_by_activity_type(scoped_results, value)
-    scoped_results.where(nominee_activity: value).or(scoped_results.where(secondary_activity: value))
+    value = value.reject { |v| v == ''}
+    value = value.map do |v|
+      v == "not_stated" ? nil : v
+    end
+    if value.include?(nil)
+      scoped_results.where(nominee_activity: value).or(scoped_results.where(nominee_activity: value).and(scoped_results.where(secondary_activity: (value unless value == nil))))
+    else
+
+      scoped_results.where(nominee_activity: value).or(scoped_results.where(secondary_activity: value))
+    end
   end
 
   def filter_by_assigned_ceremonial_county(scoped_results, value)

--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -24,15 +24,15 @@ class FormAnswerSearch < Search
 
   def filter_by_activity_type(scoped_results, value)
     value = value.reject { |v| v == ''}
+
     value = value.map do |v|
       v == "not_stated" ? nil : v
     end
-    if value.include?(nil)
-      scoped_results.where(nominee_activity: value).or(scoped_results.where(nominee_activity: value).and(scoped_results.where(secondary_activity: (value unless value == nil))))
-    else
 
-      scoped_results.where(nominee_activity: value).or(scoped_results.where(secondary_activity: value))
-    end
+    nominee_activity_scope = scoped_results.where(nominee_activity: value)
+    secondary_activity_scope = scoped_results.where(secondary_activity: value)
+
+    nominee_activity_scope.or(secondary_activity_scope.and(scoped_results.where.not(secondary_activity: nil)))
   end
 
   def filter_by_assigned_ceremonial_county(scoped_results, value)

--- a/app/search/form_answer_status/filtering_helper.rb
+++ b/app/search/form_answer_status/filtering_helper.rb
@@ -50,9 +50,12 @@ module FormAnswerStatus::FilteringHelper
   end
 
   def activity_options
-    Hash[NomineeActivityHelper.nominee_activities.collect { |activity|
-      [activity, { label: NomineeActivityHelper.lookup_label_for_activity(activity), nominee_activity: [activity] }]
-    } ]
+    options = Hash[not_stated: { label: "Not stated" }]
+    NomineeActivityHelper.nominee_activities.collect do |activity, _|
+      options[activity.to_s] = { label: NomineeActivityHelper.lookup_label_for_activity(activity) }
+    end
+
+    options
   end
 
   def address_county_options

--- a/app/views/admin/form_answers/_csv_reports_links.html.slim
+++ b/app/views/admin/form_answers/_csv_reports_links.html.slim
@@ -1,6 +1,6 @@
 .govuk-button-group
-  = link_to "Download nomination data CSV", admin_form_answers_path(search_id: params[:search_id], report_kind: "nomination_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post
+  = link_to "Download nomination data CSV", admin_form_answers_path(search_id: params[:search_id], year: params[:year], report_kind: "nomination_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post
 
-  = link_to "Download local assessment data CSV", admin_form_answers_path(search_id: params[:search_id], report_kind: "local_assessment_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post
+  = link_to "Download local assessment data CSV", admin_form_answers_path(search_id: params[:search_id], year: params[:year], report_kind: "local_assessment_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post
 
-  = link_to "Download national assessment data CSV", admin_form_answers_path(search_id: params[:search_id], report_kind: "national_assessment_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post
+  = link_to "Download national assessment data CSV", admin_form_answers_path(search_id: params[:search_id], year: params[:year], report_kind: "national_assessment_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -3,8 +3,9 @@
 h1.govuk-heading-xl
   | Nominations for your sub-group
 = simple_form_for @search, url: assessor_form_answers_path(year: params[:year]), method: :post, as: :search do |f|
-  .govuk-grid-row
-    = render "layouts/vertical_admin_award_year"
+  / Temporarily commenting out year filter for assessors
+  / .govuk-grid-row
+  /   = render "layouts/vertical_admin_award_year"
 
   .govuk-grid-row
     .govuk-grid-column-one-third


### PR DESCRIPTION
Card: https://app.asana.com/0/1199154381249427/1202057858108917/f

- Applies params[:year] to CSV scope.
- Temporarily commenting out filters for assessors
- Allow filtering where activity type is 'not_stated'
- Filter by AwardYear from params[:year] if present