### PR TITLE
Adds search and year params

### DIFF
--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -5,10 +5,10 @@
       td.govuk-table__cell = check_box_tag "check_#{obj.id}", obj.id, false, class: "form-answer-check", aria: { label: "Select nomination #{obj.id} for bulk action" }
     td.td-title.govuk-table__cell
       - if obj.company_or_nominee_name.present?
-        = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
           = obj.company_or_nominee_name
       - else
-        = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
           em
             ' Not yet specified
     td.govuk-table__cell = obj.dashboard_status
@@ -34,9 +34,6 @@
         span.muted
           = obj.last_updated_by
     td.govuk-table__cell
-      - if obj.company_or_nominee_name.present?
-        = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
-          | View
-      - else
-        = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
-          | View
+      - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
+      = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+        | View

--- a/app/views/admin/form_answers/show.html.slim
+++ b/app/views/admin/form_answers/show.html.slim
@@ -1,5 +1,5 @@
 - content_for :before_main_content do
-  = link_to "Back to nominations list", admin_form_answers_path, class: "govuk-back-link"
+  = link_to "Back to nominations list", admin_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = resource.nominee_name

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -2,7 +2,7 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj]), class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), class: 'govuk-link' do
           - unless obj.nominee_name.nil?
             span
               = obj.nominee_name
@@ -32,9 +32,6 @@ tbody.govuk-table__body
           = obj.last_updated_by
 
       td.govuk-table__cell
-        - if obj.company_or_nominee_name.present?
-          = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination, for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
-            | View
-        - else
-          = link_to polymorphic_url([namespace_name, obj]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
-            | View
+        - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+          | View

--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -1,5 +1,5 @@
 -content_for :before_main_content do
-  = link_to "Back to nominations list", assessor_form_answers_path, class: "govuk-back-link"
+  = link_to "Back to nominations list", assessor_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = @form_answer.nominee_name

--- a/app/views/lieutenant/form_answers/_list_body.html.slim
+++ b/app/views/lieutenant/form_answers/_list_body.html.slim
@@ -2,16 +2,12 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj]),
-                  aria: { label: "View nomination for #{obj.company_or_nominee_name}" },
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]),
+                  aria: { label: "View submitted nomination, for #{obj.company_or_nominee_name}" },
                   class: 'govuk-link' do
-          - unless obj.nominee_name.nil?
-            span
-              = obj.nominee_name
-          - else
-            em
-              ' Not found
-
+          span
+            = obj.nominee_name
+          
       td.govuk-table__cell = obj.dashboard_status
 
       td.govuk-table__cell = obj.document["nominee_address_postcode"]
@@ -30,6 +26,6 @@ tbody.govuk-table__body
 
       td.govuk-table__cell
         = link_to "View",
-                  lieutenant_form_answer_path(obj),
-                  aria: { label: "View nomination for #{obj.company_or_nominee_name}" },
+                  lieutenant_form_answer_path(obj, search_id: params[:search_id], year: params[:year]),
+                  aria: { label: "View submitted nomination, for #{obj.company_or_nominee_name}" },
                   class: 'govuk-link'

--- a/app/views/lieutenant/form_answers/show.html.slim
+++ b/app/views/lieutenant/form_answers/show.html.slim
@@ -1,7 +1,7 @@
 - title "#{resource.nominee_name} nomination"
 
 - content_for :before_main_content do
-  = link_to "Back to nominations list", lieutenant_form_answers_path, class: "govuk-back-link"
+  = link_to "Back to nominations list", lieutenant_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = resource.nominee_name


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1202087269805838
Stop the award year filter from resetting when a user clicks on a nomination and then uses the ‘Back to nominations list’

- passes params for search_id and year when viewing a nomination
- permits params when navigating back to the nomination list
- refactor aria_label when company name is not present

