### PR TITLE
Year select label

### DIFF
--- a/app/views/layouts/_vertical_admin_award_year.html.slim
+++ b/app/views/layouts/_vertical_admin_award_year.html.slim
@@ -11,10 +11,8 @@
 
         = params[:year].to_s == "all_years" ? "All Years" : current_year_text
       ul.dropdown-menu
-        / Commented out option for All Years as this will cause issues with the different county options. Can be uncommented when there is a single county list to use.
-
-        / li class="#{'active' if params[:year].to_s == 'all_years'}"
-        /   = link_to "All Years", url_for(params.permit(:controller, :action, :search_id, :year).merge(year: :all_years)), class: "govuk-!-font-size-19 govuk-link--no-underline"
+        li class="#{'active' if params[:year].to_s == 'all_years'}"
+          = link_to "All Years", url_for(params.permit(:controller, :action, :search_id, :year).merge(year: :all_years)), class: "govuk-!-font-size-19 govuk-link--no-underline"
 
         - AwardYear.admin_switch.each do |year, label|
           li class="#{'active' if label == current_year_text}"


### PR DESCRIPTION
https://app.asana.com/0/home/1200061634431011/1202103937470459

- Adds a visible label to the award year select button.
- Updates the aria-label to have the same copy.

- Reinstates the 'All years' option for the dropdown menu. This was removed due to having different county lists for each year. This has now been made consistent so the option can be reinstated.

![Screenshot 2022-04-11 at 14 14 53](https://user-images.githubusercontent.com/65811538/162747744-3c2b1231-5c94-47fd-81cb-00fd7367088d.png)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202103937470459