### PR TITLE
[QAVS0422] - Change GL dashboard settings to reflect nomination year

### DIFF
--- a/app/controllers/group_leader/dashboard_controller.rb
+++ b/app/controllers/group_leader/dashboard_controller.rb
@@ -3,8 +3,8 @@ class GroupLeader::DashboardController < GroupLeader::BaseController
     authorize :group_leader_dashboard, :index?
     @citation = current_subject.form_answer.citation
     @invite = palace_invite
-
-    @deadlines = Settings.current.deadlines
+    @award_year = current_subject.form_answer.award_year
+    @deadlines = @award_year.settings.deadlines
   end
 
   private

--- a/app/views/group_leader/dashboard/index.html.slim
+++ b/app/views/group_leader/dashboard/index.html.slim
@@ -3,7 +3,7 @@
 .dashboard.article-container.article-container-wider
   .dashboard__header
     h1.govuk-heading-l
-      | Congratulations on being awarded The Queen’s Award for Voluntary Service
+      | Congratulations on being awarded The Queen's Award for Voluntary Service
 
   .dashboard__section
     .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
@@ -27,7 +27,7 @@
     h3.govuk-heading-s
       | By
       =<> @deadlines.buckingham_palace_confirm_press_book_notes.strftime("%-d %B %Y")
-      | &mdash; confirm your group’s name and citation &nbsp;
+      | &mdash; confirm your group's name and citation &nbsp;
       - if @citation.completed_at?
         strong.govuk-tag.govuk-tag--blue
           | Complete
@@ -78,7 +78,9 @@
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
     h3.govuk-heading-s
-      | June to September 2022 &mdash; Lord-Lieutenant presents the Award
+      | June to September
+      =<> @award_year.year-1
+      | &mdash; Lord-Lieutenant presents the Award
     p.govuk-body
       | The Lord-Lieutenant for your local county, as The Queen's representative, will present your group with a certificate and a commemorative crystal at a local ceremony. The Lieutenancy office will be in touch to arrange a suitable date and time for this.
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
@@ -95,7 +97,7 @@
           | Incomplete
     p.govuk-body
       | Two representatives from the awarded groups will be invited to attend a Royal Garden Party at Buckingham Palace or The Palace of Holyroodhouse in Edinburgh in
-      =< AwardYear.current.year
+      =< @award_year.year
       | . We will contact you at the end of the year to request the contact details for these two guests.
       strong.text-underline<
         | No action is needed now.
@@ -104,6 +106,10 @@
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
     h3.govuk-heading-s
-      | May to July 2023 &mdash; Royal Garden Party
+      | May to July
+      =<> @award_year.year
+      | &mdash; Royal Garden Party
     p.govuk-body
-      |  We will let you know the precise dates when we contact you about this in early 2023.
+      |  We will let you know the precise dates when we contact you about this in early
+      =< @award_year.year
+      | .

--- a/spec/features/group_leaders/sign_in_spec.rb
+++ b/spec/features/group_leaders/sign_in_spec.rb
@@ -16,6 +16,6 @@ describe "GroupLeader sign in" do
 
     click_button "Sign in"
 
-    expect(page).to have_content("Congratulations on being awarded The Queen’s Award for Voluntary Service")
+    expect(page).to have_content("Congratulations on being awarded The Queen's Award for Voluntary Service")
   end
 end


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1202103937470460/
Currently, the dates in the group leader dashboard are being pulled from the year that is active. So a group leader from a winning nomination for the year 2022 will see settings from the year 2023 (the year that's currently open).
This needs to be changed so that GL see dates and information for their relevant year.

- updated deadlines in the controller to use settings for the `form_answer.award_year`
- removed hardcoded years in the dashboard

![Screenshot 2022-04-12 at 11 58 41](https://user-images.githubusercontent.com/65811538/162945711-eff37085-f338-4b03-b544-c770438471a3.png)

