### PR TITLE
change scope of the unsuccessful GL notifications

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -77,6 +77,7 @@ class FormAnswer < ApplicationRecord
     scope :not_shortlisted, -> { where(state: "not_recommended") }
     scope :winners, -> { where(state: "awarded") }
     scope :unsuccessful_applications, -> { submitted.where("state not in ('awarded', 'withdrawn')") }
+    scope :unsuccessful_applications_for_group_leader_mailer, -> { submitted.where(state: %w[local_assessment_recommended local_assessment_not_recommended not_awarded]) }
     scope :submitted, -> { where.not(submitted_at: nil) }
     scope :positive, -> { where(state: FormAnswerStateMachine::POSITIVE_STATES) }
     scope :at_post_submission_stage, -> { where(state: FormAnswerStateMachine::POST_SUBMISSION_STATES) }

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -118,7 +118,7 @@ class Notifiers::EmailNotificationService
   end
 
   def unsuccessful_group_leaders_notification(award_year)
-    award_year.form_answers.unsuccessful_applications.each do |form_answer|
+    award_year.form_answers.unsuccessful_applications_for_group_leader_mailer.each do |form_answer|
       GroupLeadersMailers::NotifyUnsuccessfulNominationsMailer.notify(form_answer.id).deliver_now!
     end
   end


### PR DESCRIPTION
should only get sent to:

Local assessment - recommended (but not later changed to 'awarded')
Local assessment - not recommended
National assessment - not recommended

https://app.asana.com/0/1199154381249427/1202305344458491