### PR TITLE
[QAVS0522] Changes to the 'UNSUCCESSFUL: Email to nominators

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -78,6 +78,7 @@ class FormAnswer < ApplicationRecord
     scope :winners, -> { where(state: "awarded") }
     scope :unsuccessful_applications, -> { submitted.where("state not in ('awarded', 'withdrawn')") }
     scope :unsuccessful_applications_for_group_leader_mailer, -> { submitted.where(state: %w[local_assessment_recommended local_assessment_not_recommended not_recommended not_awarded]) }
+    scope :unsuccessful_applications_for_nominator_mailer, -> { submitted.where(state: %w[local_assessment_recommended local_assessment_not_recommended not_recommended not_awarded]) }
     scope :submitted, -> { where.not(submitted_at: nil) }
     scope :positive, -> { where(state: FormAnswerStateMachine::POSITIVE_STATES) }
     scope :at_post_submission_stage, -> { where(state: FormAnswerStateMachine::POST_SUBMISSION_STATES) }

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -130,7 +130,7 @@ class Notifiers::EmailNotificationService
   end
 
   def unsuccessful_notification(award_year)
-    award_year.form_answers.unsuccessful_applications.each do |form_answer|
+    award_year.form_answers.unsuccessful_applications_for_nominator_mailer.each do |form_answer|
       AccountMailers::NotifyUnsuccessfulNominationsMailer.notify(form_answer.id).deliver_now!
     end
   end

--- a/app/views/account_mailers/notify_unsuccessful_nominations_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_unsuccessful_nominations_mailer/notify.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @user_name %>,
+Dear Nominator,
 
 Thank you for your nomination for <%= @group_name %> for The Queen’s Award for Voluntary Service last year.  The standard was extremely high and, in the end, the group was not selected for the Award.  However, the judges were impressed by the commitment of volunteers in all the groups considered and Sir Martyn Lewis CBE has written to group leaders to thank them personally for their work.
 

--- a/app/views/account_mailers/notify_unsuccessful_nominations_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_unsuccessful_nominations_mailer/preview/notify.html.slim
@@ -1,5 +1,5 @@
 p.govuk-body style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | Dear #{ @user_name },
+  | Dear Nominator,
 
 p.govuk-body style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Thank you for your nomination for


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1202339703930603

Removes personalisation on unsuccessful mailer
Adds new scope for unsuccessful_applications_for_nominator_mailer