### PR TITLE
Remove condition for editing group name

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -382,10 +382,7 @@ class FormAnswer < ApplicationRecord
   end
 
   def assign_searching_attributes
-    unless submitted_and_after_the_deadline?
-      self.company_or_nominee_name = company_or_nominee_from_document
-    end
-
+    self.company_or_nominee_name = company_or_nominee_from_document
     self.nominee_full_name = nominee_full_name_from_document
   end
 


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1203264867377040

`assign_searching_attributes` is called when saving the form answer.