### PR TITLE
Duplicates pagination above the assessors form_answer table

### DIFF
--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -29,6 +29,8 @@ h1.govuk-heading-xl
 
   = render("assessor/form_answers/category_tabs")
 
+  = paginate @form_answers
+
   div role="region" aria-labelledby="nomination-list-caption" tabindex="0"
     table.applications-table.govuk-table
       caption.govuk-table__caption.govuk-table__caption--m#nomination-list-caption


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1203264867377035/f

Adds pagination above the form answer table on the Assessor view

<img width="1418" alt="Screenshot 2022-11-11 at 08 27 44" src="https://user-images.githubusercontent.com/65811538/201298615-dc4d0933-8d91-487d-b94b-591a19af472c.png">
