### PR TITLE
Adds CSV download link for assessors

### DIFF
--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -48,6 +48,27 @@ class Assessor::FormAnswersController < Assessor::BaseController
                       .with_comments_counters
                       .group("form_answers.id")
                       .page(params[:page])
+
+    respond_to do |format|
+      format.html
+
+      format.csv do
+        timestamp = Time.zone.now.strftime("%d-%m-%Y")
+
+        case params[:report_kind]
+        when "assessor_decisions_data"
+          csv = Reports::AssessorDecisionsReport.new(@search.results.includes(assessor_assignments: :assessor), @award_year, current_assessor).build
+          filename = "assessor_decisions_report_#{timestamp}.csv"
+        end
+
+        send_data(
+          csv.force_encoding(::Encoding::UTF_8),
+          filename: filename,
+          type: 'text/csv; charset=Unicode(UTF-8); header=present',
+          disposition: 'attachment'
+        )
+      end
+    end
   end
 
   def show

--- a/app/models/reports/assessment.rb
+++ b/app/models/reports/assessment.rb
@@ -1,9 +1,28 @@
 class Reports::Assessment
   attr_reader :assessment, :year
 
-  def initialize(assessment, year)
+  def initialize(form_answer, assessment, year)
     @assessment = assessment
+    @form_answer = form_answer
     @year = year
+  end
+
+  def call_method(method_name)
+    return "not implemented" if method_name.blank?
+
+    if respond_to?(method_name, true)
+      public_send(method_name)
+    elsif @form_answer.respond_to?(method_name)
+      @form_answer.public_send(method_name)
+    elsif method_name.starts_with?("na_")
+      if @assessment
+        @assessment.document[(method_name.gsub(/(^na_)|(_\d$)/, ''))]
+      else
+        ""
+      end
+    else
+      "missing method"
+    end
   end
 
   def fetch(method_name)
@@ -12,5 +31,9 @@ class Reports::Assessment
     else
       assessment.document[method_name]
     end
+  end
+
+  def ceremonial_county
+    @form_answer.ceremonial_county.try(:name)
   end
 end

--- a/app/models/reports/assessor_decisions_report.rb
+++ b/app/models/reports/assessor_decisions_report.rb
@@ -1,0 +1,80 @@
+# coding: utf-8
+class Reports::AssessorDecisionsReport < Reports::QavsBase
+  attr_reader :year
+
+  def initialize(scope, award_year, assessor)
+    @scope = scope
+    @year = award_year.year
+    @assessor = assessor
+  end
+
+  def build
+    CSV.generate(encoding: "UTF-8", force_quotes: true) do |csv|
+     csv << headers
+      @scope.each do |form_answer|
+        assessment = build_assessment(form_answer, @assessor)
+
+        csv << mapping.map do |m|
+          sanitize_string(
+            assessment.call_method(m[:method])
+          )
+        end
+      end
+    end
+  end
+
+  MAPPING = [
+    {
+      label: "Group name",
+      method: :company_or_nominee_name
+    },
+    {
+      label: "Ceremonial county",
+      method: :ceremonial_county
+    }
+  ]
+
+  private
+
+  def assessment_data
+    data = []
+
+    questions = AppraisalForm.const_get("QAVS_#{year}")
+    questions.each do |key, options|
+      case options[:type]
+      when :rag
+        data << {
+          label: "#{options[:label]} evaluation",
+          method: "na_#{key}_rate"
+        }
+
+        data << {
+          label: "#{options[:label]} comments",
+          method: "na_#{key}_desc"
+        }
+      when :verdict
+        data << {
+          label: "#{options[:label]}",
+          method: "na_#{key}_rate"
+        }
+
+        data << {
+          label: "#{options[:label]} comments",
+          method: "na_#{key}_desc"
+        }
+      end
+    end
+
+    data
+  end
+
+  def mapping
+    MAPPING + assessment_data
+  end
+
+  def build_assessment(form_answer, assessor)
+    assessment = form_answer.assessor_assignments.where(assessor_id: assessor.id).select(&:submitted?).first
+
+    Reports::Assessment.new(form_answer, assessment, year)
+  end
+end

--- a/app/models/reports/nomination.rb
+++ b/app/models/reports/nomination.rb
@@ -12,7 +12,7 @@ class Reports::Nomination
     @award_form = form_answer.award_form.decorate(answers: answers)
 
     @assessments = form_answer.assessor_assignments.select(&:submitted?).sort_by(&:id).map do |a|
-      Reports::Assessment.new(a, year)
+      Reports::Assessment.new(form_answer, a, year)
     end
   end
 

--- a/app/views/assessor/form_answers/_csv_reports_links.html.slim
+++ b/app/views/assessor/form_answers/_csv_reports_links.html.slim
@@ -1,0 +1,2 @@
+.govuk-button-group
+  = link_to "Download assessor decisions & comments CSV", assessor_form_answers_path(search_id: params[:search_id], year: params[:year], report_kind: "assessor_decisions_data", format: "csv"), class: "govuk-link download-link govuk-link--no-visited-state", method: :post

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -29,6 +29,9 @@ h1.govuk-heading-xl
 
   = render("assessor/form_answers/category_tabs")
 
+  hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+  = render("assessor/form_answers/csv_reports_links")
+
   div role="region" aria-labelledby="nomination-list-caption" tabindex="0"
     table.applications-table.govuk-table
       caption.govuk-table__caption.govuk-table__caption--m#nomination-list-caption

--- a/spec/models/reports/assessor_decisions_report_spec.rb
+++ b/spec/models/reports/assessor_decisions_report_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe Reports::AssessorDecisionsReport do
+  context "with empty assessments" do
+    let!(:assessor) { create(:assessor) }
+    let!(:fa) { create(:form_answer, :shortlisted, sub_group: assessor.sub_group) }
+
+    it "is rendering report with empty columns" do
+      build(:assessor_assignment, assessor: assessor, form_answer: fa)
+      scope = assessor.applications_scope(fa.award_year)
+      csv_txt = Reports::AssessorDecisionsReport.new(scope, fa.award_year, assessor).build
+      csv = CSV.parse(csv_txt, headers: true)
+
+      expect(csv.length).to eq(1)
+
+      AppraisalForm.struct(fa).each do |key, section|
+        label = section[:label]
+
+        if section[:type] == :rag
+          expect(csv.first["#{label} evaluation"]).to eq("")
+          expect(csv.first["#{label} comments"]).to eq("")
+        else
+          expect(csv.first["#{label}"]).to eq("")
+          expect(csv.first["#{label} comments"]).to eq("")
+        end
+      end
+    end
+  end
+
+  context "with assessor appraisal content" do
+    let!(:assessor) { create(:assessor) }
+    let!(:fa) { create(:form_answer, :shortlisted, sub_group: assessor.sub_group) }
+
+    it "displays report data for current assessor" do
+      aa = build(:assessor_assignment, assessor: assessor, form_answer: fa)
+
+      AppraisalForm.struct(fa).each do |key, section|
+        if section[:type] == :rag
+          aa.public_send("#{key}_rate=", "average")
+        else
+          aa.public_send("#{key}_rate=", "recommended")
+        end
+        aa.public_send("#{key}_desc=", "#{key} desc")
+      end
+      aa.submitted_at = Time.current
+
+      aa.save!
+
+      scope = assessor.applications_scope(fa.award_year)
+      csv_txt = Reports::AssessorDecisionsReport.new(scope, fa.award_year, assessor).build
+      csv = CSV.parse(csv_txt, headers: true)
+
+      AppraisalForm.struct(fa).each do |key, section|
+        label = section[:label]
+
+        desc_val = "#{key} desc"
+
+        if section[:type] == :rag
+          rate_val = "average"
+          expect(csv.first["#{label} evaluation"]).to eq(rate_val)
+          expect(csv.first["#{label} comments"]).to eq(desc_val)
+        else
+          rate_val = "recommended"
+
+          expect(csv.first["#{label}"]).to eq(rate_val)
+          expect(csv.first["#{label} comments"]).to eq(desc_val)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1202531355487421

A link is added to the Assessor nominations dashboard for a CSV report displaying an assessor decisions for each form_answer.

The assessors report on the admin dashboard loops through each assessor_assignment by index but here we only want to display the feedback for the current_assessor. 

Where the assessor has not yet provided feedback for that nomination  the column will be empty.

<img width="1523" alt="Screenshot 2022-11-14 at 14 13 41" src="https://user-images.githubusercontent.com/65811538/201683177-43096be3-a1a4-4bd3-baea-7051faa3262d.png">

<img width="1382" alt="Screenshot 2022-11-14 at 14 14 30" src="https://user-images.githubusercontent.com/65811538/201683200-47f8cf9a-38e0-40ff-bc2b-70aa3525216f.png">

