### PR TITLE
Shows unsubmitted assessment comments in report

### DIFF
--- a/app/models/reports/assessment.rb
+++ b/app/models/reports/assessment.rb
@@ -15,8 +15,8 @@ class Reports::Assessment
     elsif @form_answer.respond_to?(method_name)
       @form_answer.public_send(method_name)
     elsif method_name.starts_with?("na_")
-      if @assessment
-        @assessment.document[(method_name.gsub(/(^na_)|(_\d$)/, ""))]
+      if assessment
+        assessment.document[(method_name.gsub(/(^na_)|(_\d$)/, ""))]
       else
         ""
       end
@@ -37,7 +37,7 @@ class Reports::Assessment
     @form_answer.ceremonial_county.try(:name)
   end
 
-  def submitted?
-    @assessment&.submitted_at ? "Yes" : "No"
+  def submitted
+    assessment&.submitted_at ? "Yes" : "No"
   end
 end

--- a/app/models/reports/assessment.rb
+++ b/app/models/reports/assessment.rb
@@ -16,7 +16,7 @@ class Reports::Assessment
       @form_answer.public_send(method_name)
     elsif method_name.starts_with?("na_")
       if @assessment
-        @assessment.document[(method_name.gsub(/(^na_)|(_\d$)/, ''))]
+        @assessment.document[(method_name.gsub(/(^na_)|(_\d$)/, ""))]
       else
         ""
       end

--- a/app/models/reports/assessment.rb
+++ b/app/models/reports/assessment.rb
@@ -36,4 +36,8 @@ class Reports::Assessment
   def ceremonial_county
     @form_answer.ceremonial_county.try(:name)
   end
+
+  def submitted?
+    @assessment&.submitted_at ? "Yes" : "No"
+  end
 end

--- a/app/models/reports/assessor_decisions_report.rb
+++ b/app/models/reports/assessor_decisions_report.rb
@@ -37,7 +37,7 @@ class Reports::AssessorDecisionsReport < Reports::QavsBase
   SUBMITTED = [
     {
       label: "Submitted",
-      method: :submitted?
+      method: :submitted
     }
   ]
 

--- a/app/models/reports/assessor_decisions_report.rb
+++ b/app/models/reports/assessor_decisions_report.rb
@@ -10,7 +10,7 @@ class Reports::AssessorDecisionsReport < Reports::QavsBase
 
   def build
     CSV.generate(encoding: "UTF-8", force_quotes: true) do |csv|
-     csv << headers
+      csv << headers
       @scope.each do |form_answer|
         assessment = build_assessment(form_answer, @assessor)
 

--- a/app/models/reports/assessor_decisions_report.rb
+++ b/app/models/reports/assessor_decisions_report.rb
@@ -34,6 +34,13 @@ class Reports::AssessorDecisionsReport < Reports::QavsBase
     }
   ]
 
+  SUBMITTED = [
+    {
+      label: "Submitted",
+      method: :submitted?
+    }
+  ]
+
   private
 
   def assessment_data
@@ -69,11 +76,11 @@ class Reports::AssessorDecisionsReport < Reports::QavsBase
   end
 
   def mapping
-    MAPPING + assessment_data
+    MAPPING + assessment_data + SUBMITTED
   end
 
   def build_assessment(form_answer, assessor)
-    assessment = form_answer.assessor_assignments.where(assessor_id: assessor.id).select(&:submitted?).first
+    assessment = form_answer.assessor_assignments.where(assessor_id: assessor.id).first
 
     Reports::Assessment.new(form_answer, assessment, year)
   end


### PR DESCRIPTION
https://app.asana.com/0/1199154381249427/1202531355487421/f

Additional subtasks:

- [x] each field should fill in as a national assessor completes it/selects a decision.
  Removed the filter for submitted assessments when building the assessment for the report.
- [x] Add another column at the end called 'submitted' with values yes/no, for when the assessor has submitted the evaluation 
  Added additional column that checks the existence of the submitted_at attribute on the assessment