### PR TITLE
Fix deletion of support letter attachments

### DIFF
--- a/app/views/form/support_letters/_support_letter.html.slim
+++ b/app/views/form/support_letters/_support_letter.html.slim
@@ -31,4 +31,4 @@ li.view-only
                                                                 mount_name: :attachment
   span.clear
 
-  = button_to "Remove", form_form_answer_support_letter_path(@form_answer, support_letter), method: :delete, class: "govuk-button govuk-button--warning #{'read_only' if admin_in_read_only_mode?}", 'aria-label' => "Delete support letter from #{support_letter.first_name} #{support_letter.first_name}"
+  = button_to "Remove", form_form_answer_support_letter_path(@form_answer, support_letter), method: :delete, class: "govuk-button govuk-button--warning #{'read_only' if admin_in_read_only_mode?}", 'aria-label' => "Delete support letter from #{support_letter.first_name} #{support_letter.last_name}"

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -50,6 +50,4 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
       - url = "#"
 
     - if submission_deadline.trigger_at >= Time.zone.now
-      button.govuk-button.govuk-button--warning.remove-supporter.remove-link.js-remove-link.visible-read-only class="#{'read_only' if admin_in_read_only_mode?}"
-        | Remove
-
+      = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"

--- a/app/views/qae_form/_supporter_fields_placeholder.html.slim
+++ b/app/views/qae_form/_supporter_fields_placeholder.html.slim
@@ -30,8 +30,3 @@ li.js-add-example class="govuk-!-display-none"
 
   button.govuk-button.button-alt.js-save-collection data-save-collection-url=users_form_answer_support_letters_url(@form_answer) disabled='disabled'
     | Submit letter of support
-
-  p
-    - if !admin_in_read_only_mode?
-      button.govuk-button.govuk-button--warning.remove-supporter.remove-link.js-remove-link.govuk-button.govuk-button--warning.visible-read-only
-        | Remove


### PR DESCRIPTION
## 📝 A short description of the changes

* supporter_fields - this view displays saved support letters. The Remove button was not destroying the records from the database, only the document so adding in the url and also passing this url as a data attribute along with the remove-supporter class which applies method: delete
* support_letter - fixed aria label
* supporter_fields_placeholder - remove button deleted as ID not present when removing newly added support letter

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1205441207852642

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

