### PR TITLE
Fix typo causing duplicate support letters

### DIFF
--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -48,5 +48,5 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
       - url = users_form_answer_support_letter_path(form_answer_id: @form_answer.id, id: supporter["support_letter_id"])
     - else
       - url = "#"
-    = if current_user || policy(:support_letter).can_remove?
+    - if current_user || policy(:support_letter).can_remove?
       = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"


### PR DESCRIPTION
## 📝 A short description of the changes

* Fixing a typo causing letters of support to show twice

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1205441207852642/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
