### PR TITLE
add ability to restore lieutenants for admins

### DIFF
--- a/app/controllers/admin/lieutenants_controller.rb
+++ b/app/controllers/admin/lieutenants_controller.rb
@@ -4,9 +4,18 @@ class Admin::LieutenantsController < Admin::UsersController
     params[:search].permit!
     authorize :lieutenant, :index?
 
-    @search = LieutenantSearch.new(Lieutenant.all).
-                             search(params[:search])
+    @search = LieutenantSearch.new(Lieutenant.all)
+                .search(params[:search])
     @resources = @search.results.page(params[:page])
+  end
+
+  def deleted
+    authorize :lieutenant, :restore?
+
+    @search = LieutenantSearch.new(Lieutenant.deleted)
+                .search(params[:search])
+    @resources = @search.results.page(params[:page])
+    render :index
   end
 
   def new
@@ -41,6 +50,18 @@ class Admin::LieutenantsController < Admin::UsersController
                  @resource,
                  location: admin_lieutenants_path,
                  notice: "User has been successfully updated."
+  end
+
+  def restore
+    @resource = Lieutenant.deleted.find(params[:id])
+
+    authorize @resource, :restore?
+    @resource.restore!
+
+    respond_with :admin,
+                 @resource,
+                 location: admin_lieutenants_path,
+                 notice: "User has been successfully restored."
   end
 
   def destroy

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < Admin::BaseController
   respond_to :html
-  before_action :find_resource, except: [:index, :new, :create]
+  before_action :find_resource, except: [:index, :new, :create, :deleted, :restore]
 
   def index
     params[:search] ||= UserSearch::DEFAULT_SEARCH

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -34,18 +34,23 @@ module SearchHelper
     end
   end
 
-  def user_search_count(resource)
-     "Showing " + user_count(resource) unless resource.none?
+  def user_search_count(resource, deleted = false)
+     "Showing " + user_count(resource, deleted) unless resource.none?
   end
 
-  def user_default_count(resource)
-    "Showing all " + user_count(resource) unless resource.none?
+  def user_default_count(resource, deleted = false)
+    if deleted
+      "Showing "
+    else
+      "Showing all "
+    end + user_count(resource, deleted) unless resource.none?
   end
 
-  def user_count(resource)
+  def user_count(resource, deleted = false)
     user_type = t("admin.users.role_headers.#{controller_name}")
     user_type = user_type.downcase unless controller_name == "lieutenants"
     user_type = resource.count == 1 ? user_type.singularize : user_type
-    "#{resource.count.to_s} #{user_type}"
+    deleted_msg = " deleted" if deleted
+    "#{resource.count.to_s}#{deleted_msg.to_s} #{user_type}"
   end
 end

--- a/app/models/concerns/soft_delete.rb
+++ b/app/models/concerns/soft_delete.rb
@@ -3,9 +3,15 @@ module SoftDelete
 
   included do
     default_scope { where(deleted: false) }
+
+    scope :deleted, -> { unscoped.where(deleted: true) }
   end
 
   def soft_delete!
     update_column(:deleted, true)
+  end
+
+  def restore!
+    update_column(:deleted, false)
   end
 end

--- a/app/policies/lieutenant_policy.rb
+++ b/app/policies/lieutenant_policy.rb
@@ -11,6 +11,10 @@ class LieutenantPolicy < AdminPolicy
     admin? || (advanced_lieutenant? && same_county?)
   end
 
+  def restore?
+    admin?
+  end
+
   def destroy?
     admin? || (advanced_lieutenant? && subject != record && record.role.regular? && same_county?)
   end

--- a/app/views/admin/lieutenants/_list.html.slim
+++ b/app/views/admin/lieutenants/_list.html.slim
@@ -16,14 +16,21 @@ div role="region" aria-labelledby="table-list-lieutenancy-office-caption" tabind
           = sort_link f, "Confirmed on", @search, :confirmed_at
         th.sortable.govuk-table__header scope="col"
           = sort_link f, "Locked on", @search, :locked_at
-        th.govuk-table__header
-          | Edit
+        - if action_name == "deleted"
+          th.govuk-table__header
+            | Restore
+        - else
+          th.govuk-table__header
+            | Edit
     tbody.govuk-table__body
       - if resources.none?
         tr.govuk-table__row
           td.text-center colspan=100
             br
-            p.govuk-body.p-empty No Lord Lieutenancy office users found.
+            - if action_name == "deleted"
+              p.govuk-body.p-empty No deleted Lord Lieutenancy office users found.
+            - else
+              p.govuk-body.p-empty No Lord Lieutenancy office users found.
             br
       - else
         - LieutenantDecorator.decorate_collection(resources).each do |lieutenant|
@@ -59,7 +66,14 @@ div role="region" aria-labelledby="table-list-lieutenancy-office-caption" tabind
                 .text-muted
                   ' Not locked
             td.govuk-table__cell
-              = link_to "Edit user", edit_admin_lieutenant_path(lieutenant),
-                        class: "govuk-link",
-                        id: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }",
-                        aria: { label: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }
+              - if action_name == "deleted"
+                = link_to "Restore user", restore_admin_lieutenant_path(lieutenant),
+                          class: "govuk-link",
+                          id: "restore-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }",
+                          method: :post,
+                          aria: { label: "restore-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }
+              - else
+                = link_to "Edit user", edit_admin_lieutenant_path(lieutenant),
+                          class: "govuk-link",
+                          id: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }",
+                          aria: { label: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -18,6 +18,21 @@
         .govuk-grid-row
           = render "shared/users/search_count"
         .govuk-button-group
+          - if controller_name == "lieutenants"
+            - if action_name == "deleted"
+              = link_to "Show active users",
+                        admin_lieutenants_path,
+                        class: "new-user govuk-button pull-right",
+                        role: "button",
+                        aria: { label: "Show active users" }
+
+            - else
+              = link_to "Show deleted users",
+                        deleted_admin_lieutenants_path,
+                        class: "new-user govuk-button pull-right",
+                        role: "button",
+                        aria: { label: "Show deleted users" }
+
           = link_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user govuk-button pull-right', role: 'button' do
             = t("admin.users.new_button.#{controller_name}")
         .clear

--- a/app/views/shared/users/_search_count.html.slim
+++ b/app/views/shared/users/_search_count.html.slim
@@ -1,6 +1,6 @@
 p.govuk-body-l.govuk-grid-column-two-thirds class="govuk-!-font-weight-bold"
   - if @search.query?
-    = user_search_count(@resources)
+    = user_search_count(@resources, action_name == "deleted")
   - else
-    = user_default_count(@resources)
+    = user_default_count(@resources, action_name == "deleted")
   .clear

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,12 @@ Rails.application.routes.draw do
       end
     end
     resources :assessors
-    resources :lieutenants
+
+    resources :lieutenants do
+      get :deleted, on: :collection
+      post :restore, on: :member
+    end
+
     resources :group_leaders, except: [:new, :create, :show]
     resources :citations, only: [:index]
 

--- a/spec/features/admin/lieutenants/manage_spec.rb
+++ b/spec/features/admin/lieutenants/manage_spec.rb
@@ -52,5 +52,20 @@ describe "Admin: Lieutenant management" do
 
       expect(page).to have_no_content "Rob Bobbers"
     end
+
+    it "can restore deleted lieutenant" do
+      Lieutenant.last.soft_delete!
+
+      visit admin_lieutenants_path
+      expect(page).not_to have_content "Bob Bobbers"
+
+      click_link "Show deleted users"
+      click_link "Restore user"
+
+      expect(page).to have_content "User has been successfully restored"
+
+      visit admin_lieutenants_path
+      expect(page).to have_content "Bob Bobbers"
+    end
   end
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* add ability to restore lieutenants for admins

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206111043854989/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="1239" alt="image" src="https://github.com/bitzesty/qavs-v2/assets/332810/15a50a8a-196f-41da-8ebf-6cbea1fb3f0d">

