### PR TITLE
add ability to remove letter of support right after upload

### DIFF
--- a/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
@@ -60,7 +60,6 @@ window.SupportLetters =
   enable_item_fields_and_controls: (parent) ->
     parent.find(".js-save-collection").removeClass("govuk-!-display-none")
     parent.find(".visible-read-only").hide()
-    parent.find(".remove-link").removeClass("govuk-!-display-none")
     fields = parent.find("input")
     fields.removeClass("read-only")
     parent.find(".govuk-error-message").html("")
@@ -124,6 +123,7 @@ window.SupportLetters =
               SupportLetters.disable_item_fields_and_controls(parent)
               window.FormValidation.validateStep()
               SupportLetters.autosave()
+              SupportLetters.showRemoveLink(parent, data, response)
 
               return
             error: (response) ->
@@ -154,3 +154,9 @@ window.SupportLetters =
         type: 'POST'
         dataType: 'json'
       })
+
+  showRemoveLink: (parent, data, response) ->
+    removeLink = $(".remove-supporter", parent)
+    removeLink.data("url", "/users/form_answers/#{response['form_answer_id']}/support_letters/#{response['id']}")
+    removeLink.attr("aria-label", "Delete support letter from #{data['support_letter']['first_name']} #{data['support_letter']['last_name']}")
+    removeLink.removeClass("govuk-!-display-none")

--- a/app/controllers/users/support_letters_controller.rb
+++ b/app/controllers/users/support_letters_controller.rb
@@ -30,7 +30,7 @@ class Users::SupportLettersController < Users::BaseController
       attachment.support_letter = support_letter
       attachment.save!
 
-      render json: support_letter.id,
+      render json: { id: support_letter.id, form_answer_id: form_answer.id },
              status: :created
     else
       render json: support_letter.errors.messages.to_json,

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -43,10 +43,13 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
     button.govuk-button.js-save-collection class=(persisted ? "visuallyhidden" : "") data-save-collection-url=users_form_answer_support_letters_url(@form_answer)
       | Submit letter of support
 
-  - if !admin_in_read_only_mode? && persisted
-    - if supporter["support_letter_id"].present? && @form_answer.support_letters.find_by_id(supporter["support_letter_id"])
-      - url = users_form_answer_support_letter_path(form_answer_id: @form_answer.id, id: supporter["support_letter_id"])
+  - if !admin_in_read_only_mode?
+    - if persisted
+      - if supporter["support_letter_id"].present? && @form_answer.support_letters.find_by_id(supporter["support_letter_id"])
+        - url = users_form_answer_support_letter_path(form_answer_id: @form_answer.id, id: supporter["support_letter_id"])
+      - else
+        - url = "#"
+      - if current_user || policy(:support_letter).can_remove?
+        = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"
     - else
-      - url = "#"
-    - if current_user || policy(:support_letter).can_remove?
-      = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"
+      = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { url: "#" }, 'aria-label' => "#"

--- a/app/views/qae_form/_supporter_fields_placeholder.html.slim
+++ b/app/views/qae_form/_supporter_fields_placeholder.html.slim
@@ -28,5 +28,8 @@ li.js-add-example class="govuk-!-display-none"
     span.govuk-error-message
     input class="js-trigger-autosave js-support-letter-attachment govuk-input medium" name="form[#{question.key}][{index}][letter_of_support]" id="form[#{question.key}][{index}][letter_of_support]" type='file' disabled=true
 
-  button.govuk-button.button-alt.js-save-collection data-save-collection-url=users_form_answer_support_letters_url(@form_answer) disabled='disabled'
-    | Submit letter of support
+  p
+    button.govuk-button.button-alt.js-save-collection data-save-collection-url=users_form_answer_support_letters_url(@form_answer) disabled='disabled'
+      | Submit letter of support
+
+    = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { url: "#" }, 'aria-label' => "#"


### PR DESCRIPTION
## 📝 A short description of the changes

* fix a bug where right after uploading the button did not appear

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206476383518318/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

