### PR TITLE
hide buttons after submission deadline is passed if form is not editable

### DIFF
--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -43,7 +43,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
     button.govuk-button.js-save-collection class=(persisted ? "visuallyhidden" : "") data-save-collection-url=users_form_answer_support_letters_url(@form_answer)
       | Submit letter of support
 
-  - if !admin_in_read_only_mode?
+  - if current_form_is_editable?
     - if persisted
       - if supporter["support_letter_id"].present? && @form_answer.support_letters.find_by_id(supporter["support_letter_id"])
         - url = users_form_answer_support_letter_path(form_answer_id: @form_answer.id, id: supporter["support_letter_id"])

--- a/app/views/qae_form/_supporters_question.html.slim
+++ b/app/views/qae_form/_supporters_question.html.slim
@@ -12,5 +12,6 @@ ul.list-add.supporters-list data-need-to-clear-example=true data-add-limit=quest
     - (0...question.default.to_i).each do |index|
       = render 'qae_form/supporter_fields', question: question, supporter: {}, index: index
 
-a.govuk-button.govuk-button--secondary.button-add.js-button-add href="#" *possible_read_only_ops(question.step.opts[:id])
-  | Add another letter of support
+- if current_form_is_editable?
+  a.govuk-button.govuk-button--secondary.button-add.js-button-add href="#" *possible_read_only_ops(question.step.opts[:id])
+    | Add another letter of support


### PR DESCRIPTION
## 📝 A short description of the changes

* previously we showed the buttons allowing user in theory to bypass the validations and add 3rd letter of support 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206476387974016

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

