### PR TITLE
remove ability for assessors/lieutenants to delete support letters

### DIFF
--- a/app/controllers/form/support_letters_controller.rb
+++ b/app/controllers/form/support_letters_controller.rb
@@ -30,6 +30,9 @@ class Form::SupportLettersController < Form::BaseController
   end
 
   def destroy
+    # safeguard for the case when not a user tries to delete a letter
+    return if current_assessor || current_leutenant
+
     if @support_letter.destroy
       remove_support_letter_from_document!
       @form_answer.save

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -43,7 +43,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
     button.govuk-button.js-save-collection class=(persisted ? "visuallyhidden" : "") data-save-collection-url=users_form_answer_support_letters_url(@form_answer)
       | Submit letter of support
 
-  - if current_form_is_editable?
+  - if current_form_is_editable? && !current_lieutenant && !current_assessor
     - if persisted
       - if supporter["support_letter_id"].present? && @form_answer.support_letters.find_by_id(supporter["support_letter_id"])
         - url = users_form_answer_support_letter_path(form_answer_id: @form_answer.id, id: supporter["support_letter_id"])


### PR DESCRIPTION
## 📝 A short description of the changes

* add check for button rendering and controller action

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206476387974026

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

