### PR TITLE
Adds confirm popup when removing letters of support

### DIFF
--- a/app/views/form/support_letters/_support_letter.html.slim
+++ b/app/views/form/support_letters/_support_letter.html.slim
@@ -31,4 +31,7 @@ li.view-only
                                                                 mount_name: :attachment
   span.clear
 
-  = button_to "Remove", form_form_answer_support_letter_path(@form_answer, support_letter), method: :delete, class: "govuk-button govuk-button--warning #{'read_only' if admin_in_read_only_mode?}", 'aria-label' => "Delete support letter from #{support_letter.first_name} #{support_letter.last_name}"
+  = button_to "Remove", form_form_answer_support_letter_path(@form_answer, support_letter),
+              data: { method: :delete, confirm: 'Are you sure you want to delete this letter of support?' },
+              class: "govuk-button govuk-button--warning #{'read_only' if admin_in_read_only_mode?}",
+              'aria-label' => "Delete support letter from #{support_letter.first_name} #{support_letter.last_name}"

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -50,6 +50,6 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
       - else
         - url = "#"
       - if current_user || policy(:support_letter).can_remove?
-        = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"
+        = link_to "Remove", url, class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link", data: { confirm: 'Are you sure you want to delete this letter of support?', url: url }, 'aria-label' => "Delete support letter from #{supporter["first_name"]} #{supporter["last_name"]}"
     - else
-      = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { url: "#" }, 'aria-label' => "#"
+      = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { confirm: 'Are you sure you want to delete this letter of support?', url: "#" }, 'aria-label' => "#"

--- a/app/views/qae_form/_supporter_fields_placeholder.html.slim
+++ b/app/views/qae_form/_supporter_fields_placeholder.html.slim
@@ -32,4 +32,4 @@ li.js-add-example class="govuk-!-display-none"
     button.govuk-button.button-alt.js-save-collection data-save-collection-url=users_form_answer_support_letters_url(@form_answer) disabled='disabled'
       | Submit letter of support
 
-    = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { url: "#" }, 'aria-label' => "#"
+    = link_to "Remove", "#", class: "govuk-button govuk-button--warning remove-supporter remove-link js-remove-link govuk-!-display-none", data: { confirm: 'Are you sure you want to delete this letter of support?', url: "#" }, 'aria-label' => "#"


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds popup confirmation when removing letters of support

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206580439748043/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="759" alt="Screenshot 2024-02-13 at 10 51 00" src="https://github.com/bitzesty/qavs-v2/assets/65811538/a0c3ee63-19de-4233-a2a1-ef9d4aaafc16">
