### PR TITLE
Adds target _blank to nomination table links

### DIFF
--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -5,10 +5,10 @@
       td.govuk-table__cell = check_box_tag "check_#{obj.id}", obj.id, false, class: "form-answer-check", aria: { label: "Select nomination #{obj.id} for bulk action" }
     td.td-title.govuk-table__cell
       - if obj.company_or_nominee_name.present?
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link', target: :_blank do
           = obj.company_or_nominee_name
       - else
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link', target: :_blank do
           em
             ' Not yet specified
     td.govuk-table__cell = obj.dashboard_status
@@ -35,5 +35,5 @@
           = obj.last_updated_by
     td.govuk-table__cell
       - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
-      = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+      = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link', target: :_blank do
         | View

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -2,7 +2,7 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), class: 'govuk-link', target: :_blank do
           - unless obj.nominee_name.nil?
             span
               = obj.nominee_name
@@ -33,5 +33,5 @@ tbody.govuk-table__body
 
       td.govuk-table__cell
         - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link', target: :_blank do
           | View


### PR DESCRIPTION
 ## 📝 A short description of the changes

* Opens a new tab for links on the nominations table for admins and assessors only

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206580439748047

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
