### PR TITLE
Passes search and page params to paths

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -1,5 +1,7 @@
 class Admin::AdminsController < Admin::UsersController
   before_action :find_resource, except: [:index, :new, :create, :login_as_assessor, :login_as_user, :console]
+  before_action :permit_search_params, except: [:index]
+
   def index
     params[:search] ||= AdminSearch::DEFAULT_SEARCH
     params[:search].permit!
@@ -21,7 +23,7 @@ class Admin::AdminsController < Admin::UsersController
     authorize @resource, :create?
 
     @resource.save
-    location = @resource.persisted? ? admin_admins_path : nil
+    location = @resource.persisted? ? admin_admins_path(search: params[:search], page: params[:page]) : nil
     respond_with :admin, @resource, location: location
   end
 
@@ -34,14 +36,18 @@ class Admin::AdminsController < Admin::UsersController
       @resource.update_without_password(resource_params)
     end
 
-    respond_with :admin, @resource, location: admin_admins_path
+    respond_with :admin,
+                 @resource,
+                 location: admin_admins_path(search: params[:search], page: params[:page])
   end
 
   def destroy
     authorize @resource, :destroy?
     @resource.soft_delete!
 
-    respond_with :admin, @resource, location: admin_admins_path
+    respond_with :admin,
+                @resource,
+                location: admin_admins_path(search: params[:search], page: params[:page])
   end
 
   # NOTE: debug abilities for Admin - BEGIN
@@ -79,5 +85,9 @@ class Admin::AdminsController < Admin::UsersController
              :password_confirmation,
              :first_name,
              :last_name)
+  end
+
+  def permit_search_params
+    params[:search].permit!
   end
 end

--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -88,6 +88,6 @@ class Admin::AdminsController < Admin::UsersController
   end
 
   def permit_search_params
-    params[:search].permit!
+    params[:search].permit! if params[:search].present?
   end
 end

--- a/app/controllers/admin/assessors_controller.rb
+++ b/app/controllers/admin/assessors_controller.rb
@@ -1,4 +1,6 @@
 class Admin::AssessorsController < Admin::UsersController
+  before_action :permit_search_params, except: [:index]
+
   def index
     params[:search] ||= AssessorSearch::DEFAULT_SEARCH
     params[:search].permit!
@@ -21,7 +23,7 @@ class Admin::AssessorsController < Admin::UsersController
     authorize @resource, :create?
 
     @resource.save
-    location = @resource.persisted? ? admin_assessors_path : nil
+    location = @resource.persisted? ? admin_assessors_path(search: params[:search], page: params[:page]) : nil
     respond_with :admin, @resource, location: location, notice: "User has been successfully added."
   end
 
@@ -34,14 +36,19 @@ class Admin::AssessorsController < Admin::UsersController
       @resource.update_without_password(resource_params)
     end
 
-    respond_with :admin, @resource, location: admin_assessors_path, notice: "User has been updated."
+    respond_with :admin,
+                 @resource,
+                 location: admin_assessors_path(search: params[:search], page: params[:page]),
+                 notice: "User has been updated."
   end
 
   def destroy
     authorize @resource, :destroy?
     @resource.soft_delete!
 
-    respond_with :admin, @resource, location: admin_assessors_path
+    respond_with :admin,
+                 @resource,
+                 location: admin_assessors_path(search: params[:search], page: params[:page])
   end
 
   private
@@ -58,5 +65,9 @@ class Admin::AssessorsController < Admin::UsersController
              :sub_group,
              :first_name,
              :last_name)
+  end
+
+  def permit_search_params
+    params[:search].permit!
   end
 end

--- a/app/controllers/admin/assessors_controller.rb
+++ b/app/controllers/admin/assessors_controller.rb
@@ -68,6 +68,6 @@ class Admin::AssessorsController < Admin::UsersController
   end
 
   def permit_search_params
-    params[:search].permit!
+    params[:search].permit! if params[:search].present?
   end
 end

--- a/app/controllers/admin/group_leaders_controller.rb
+++ b/app/controllers/admin/group_leaders_controller.rb
@@ -1,4 +1,6 @@
 class Admin::GroupLeadersController < Admin::UsersController
+  before_action :permit_search_params, except: [:index]
+
   def index
     params[:search] ||= GroupLeaderSearch::DEFAULT_SEARCH
     params[:search].permit!
@@ -20,7 +22,7 @@ class Admin::GroupLeadersController < Admin::UsersController
 
     respond_with :admin,
                  @resource,
-                 location: admin_group_leaders_path,
+                 location: admin_group_leaders_path(search: params[:search], page: params[:page]),
                  notice: "User has been successfully updated."
   end
 
@@ -28,7 +30,9 @@ class Admin::GroupLeadersController < Admin::UsersController
     authorize @resource, :destroy?
     @resource.soft_delete!
 
-    respond_with :admin, @resource, location: admin_group_leaders_path
+    respond_with :admin,
+                 @resource,
+                 location: admin_group_leaders_path(search: params[:search], page: params[:page])
   end
 
   private
@@ -44,5 +48,9 @@ class Admin::GroupLeadersController < Admin::UsersController
              :password_confirmation,
              :first_name,
              :last_name)
+  end
+
+  def permit_search_params
+    params[:search].permit!
   end
 end

--- a/app/controllers/admin/group_leaders_controller.rb
+++ b/app/controllers/admin/group_leaders_controller.rb
@@ -51,6 +51,6 @@ class Admin::GroupLeadersController < Admin::UsersController
   end
 
   def permit_search_params
-    params[:search].permit!
+    params[:search].permit! if params[:search].present?
   end
 end

--- a/app/controllers/admin/lieutenants_controller.rb
+++ b/app/controllers/admin/lieutenants_controller.rb
@@ -93,6 +93,6 @@ class Admin::LieutenantsController < Admin::UsersController
   end
 
   def permit_search_params
-    params[:search].permit!
+    params[:search].permit! if params[:search].present?
   end
 end

--- a/app/controllers/admin/lieutenants_controller.rb
+++ b/app/controllers/admin/lieutenants_controller.rb
@@ -1,4 +1,6 @@
 class Admin::LieutenantsController < Admin::UsersController
+  before_action :permit_search_params, except: [:index]
+
   def index
     params[:search] ||= LieutenantSearch::DEFAULT_SEARCH
     params[:search].permit!
@@ -30,7 +32,7 @@ class Admin::LieutenantsController < Admin::UsersController
     authorize @resource, :create?
 
     @resource.save
-    location = @resource.persisted? ? admin_lieutenants_path : nil
+    location = @resource.persisted? ? admin_lieutenants_path(search: params[:search], page: params[:page]) : nil
     respond_with :admin,
                  @resource,
                  location: location,
@@ -48,7 +50,7 @@ class Admin::LieutenantsController < Admin::UsersController
 
     respond_with :admin,
                  @resource,
-                 location: admin_lieutenants_path,
+                 location: admin_lieutenants_path(search: params[:search], page: params[:page]),
                  notice: "User has been successfully updated."
   end
 
@@ -60,7 +62,7 @@ class Admin::LieutenantsController < Admin::UsersController
 
     respond_with :admin,
                  @resource,
-                 location: admin_lieutenants_path,
+                 location: admin_lieutenants_path(search: params[:search], page: params[:page]),
                  notice: "User has been successfully restored."
   end
 
@@ -68,7 +70,9 @@ class Admin::LieutenantsController < Admin::UsersController
     authorize @resource, :destroy?
     @resource.soft_delete!
 
-    respond_with :admin, @resource, location: admin_lieutenants_path
+    respond_with :admin,
+                 @resource,
+                 location: admin_lieutenants_path(search: params[:search], page: params[:page])
   end
 
   private
@@ -86,5 +90,9 @@ class Admin::LieutenantsController < Admin::UsersController
              :last_name,
              :role,
              :ceremonial_county_id)
+  end
+
+  def permit_search_params
+    params[:search].permit!
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,11 +1,11 @@
 class Admin::UsersController < Admin::BaseController
   respond_to :html
   before_action :find_resource, except: [:index, :new, :create, :deleted, :restore]
-  before_action :permit_search_params
+  before_action :permit_search_params, except: [:index]
 
   def index
     params[:search] ||= UserSearch::DEFAULT_SEARCH
-
+    params[:search].permit!
     authorize User, :index?
 
     @search = UserSearch.new(User.all).search(params[:search])

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -90,6 +90,6 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def permit_search_params
-    params[:search].permit!
+    params[:search].permit! if params[:search].present?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,10 +1,10 @@
 class Admin::UsersController < Admin::BaseController
   respond_to :html
   before_action :find_resource, except: [:index, :new, :create, :deleted, :restore]
+  before_action :permit_search_params
 
   def index
     params[:search] ||= UserSearch::DEFAULT_SEARCH
-    params[:search].permit!
 
     authorize User, :index?
 
@@ -28,7 +28,7 @@ class Admin::UsersController < Admin::BaseController
     authorize @resource, :create?
 
     @resource.save
-    location = @resource.persisted? ? admin_users_path : nil
+    location = @resource.persisted? ? admin_users_path(search: params[:search], page: params[:page]) : nil
     respond_with :admin, @resource, location: location
   end
 
@@ -41,7 +41,7 @@ class Admin::UsersController < Admin::BaseController
       @resource.update_without_password(resource_params)
     end
 
-    respond_with :admin, @resource, location: admin_users_path
+    respond_with :admin, @resource, location: admin_users_path(search: params[:search], page: params[:page])
   end
 
   def resend_confirmation_email
@@ -50,7 +50,7 @@ class Admin::UsersController < Admin::BaseController
     @resource.send_confirmation_instructions
     flash[:success] = "Confirmation instructions were successfully sent to #{@resource.decorate.full_name} (#{@resource.email})"
     respond_with :admin, @resource,
-                 location: admin_users_path
+                 location: admin_users_path(search: params[:search], page: params[:page])
   end
 
   def unlock
@@ -59,7 +59,7 @@ class Admin::UsersController < Admin::BaseController
     @resource.unlock_access!
     flash[:success] = "User #{@resource.decorate.full_name} (#{@resource.email}) successfully unlocked!"
     respond_with :admin, @resource,
-                 location: edit_admin_user_path(@resource)
+                 location: edit_admin_user_path(@resource, search: params[:search], page: params[:page])
   end
 
   def log_in
@@ -87,5 +87,9 @@ class Admin::UsersController < Admin::BaseController
       :password,
       :password_confirmation
     )
+  end
+
+  def permit_search_params
+    params[:search].permit!
   end
 end

--- a/app/views/admin/admins/_form.html.slim
+++ b/app/views/admin/admins/_form.html.slim
@@ -1,6 +1,9 @@
 .js-admin-strict-password-form
 
-= simple_form_for [:admin, resource], html: { class: 'qae-form' } do |f|
+= simple_form_for [:admin, resource],
+                  as: :admin,
+                  url: resource.persisted? ? admin_admin_path(resource, search: params[:search], page: params[:page]) : admin_admins_path(search: params[:search], page: params[:page]),
+                  html: { class: 'qae-form' } do |f|
 
   = render "shared/users/user_details", f: f
 
@@ -9,6 +12,11 @@
 
   .govuk-button-group class="govuk-!-margin-top-7 govuk-!-margin-bottom-9"
     = f.button :submit, class: 'govuk-button'
-    = link_to "Cancel", admin_admins_path, class: 'govuk-button govuk-button--secondary'
+    = link_to "Cancel",
+              admin_admins_path(search: params[:search], page: params[:page]),
+              class: 'govuk-button govuk-button--secondary'
     - if action_name == "edit" && policy(resource).destroy?
-      = link_to 'Delete', admin_admin_path(resource), data: { method: :delete, confirm: 'Are you sure you want to delete this user?' }, class: 'govuk-button govuk-button--warning'
+      = link_to 'Delete',
+                admin_admin_path(resource, search: params[:search], page: params[:page]),
+                data: { method: :delete, confirm: 'Are you sure you want to delete this user?' },
+                class: 'govuk-button govuk-button--warning'

--- a/app/views/admin/admins/_list.html.slim
+++ b/app/views/admin/admins/_list.html.slim
@@ -24,7 +24,7 @@ div role="region" aria-labelledby="table-list-admin-users-caption" tabindex="0"
           tr.govuk-table__row
             th.govuk-table__header scope="row"
               = link_to admin.full_name,
-                        edit_admin_admin_path(admin),
+                        edit_admin_admin_path(admin, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         aria: { label: "edit #{ admin.full_name }" }
             td.govuk-table__cell
@@ -43,7 +43,7 @@ div role="region" aria-labelledby="table-list-admin-users-caption" tabindex="0"
                   ' Not confirmed
             td.govuk-table__cell
               = link_to "Edit user",
-                        edit_admin_admin_path(admin),
+                        edit_admin_admin_path(admin, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         id: "edit-#{ admin.first_name.downcase }-#{ admin.last_name.downcase }",
                         aria: { label: "edit #{ admin.full_name }" }

--- a/app/views/admin/admins/edit.html.slim
+++ b/app/views/admin/admins/edit.html.slim
@@ -1,0 +1,9 @@
+- title t("admin.users.edit_button.#{controller_name}")
+
+- content_for :before_main_content do
+  = link_to "Back to users list", admin_admins_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
+
+h1.govuk-heading-xl
+  = t("admin.users.edit_button.#{controller_name}")
+
+= render 'form', resource: @resource

--- a/app/views/admin/admins/new.html.slim
+++ b/app/views/admin/admins/new.html.slim
@@ -1,0 +1,9 @@
+- title t("admin.users.edit_button.#{controller_name}")
+
+- content_for :before_main_content do
+  = link_to "Back to users list", admin_admins_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
+
+h1.govuk-heading-xl
+  = t("admin.users.new_button.#{controller_name}")
+
+= render 'form', resource: @resource

--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -1,4 +1,7 @@
-= simple_form_for [:admin, resource], as: :assessor, url: resource.persisted? ? admin_assessor_path(resource) : admin_assessors_path, html: { class: 'qae-form' } do |f|
+= simple_form_for [:admin, resource],
+                  as: :assessor,
+                  url: resource.persisted? ? admin_assessor_path(resource, search: params[:search], page: params[:page]) : admin_assessors_path(search: params[:search], page: params[:page]),
+                  html: { class: 'qae-form' } do |f|
   = render "shared/users/user_details", f: f
 
   = f.input :sub_group,
@@ -10,11 +13,13 @@
   - if f.object.persisted?
     = render "shared/users/password_change", f: f
 
-
   .govuk-button-group class="govuk-!-margin-top-7 govuk-!-margin-bottom-9"
     = f.submit "#{f.object.persisted? ? 'Update' : 'Add'} user", class: 'govuk-button'
     = link_to "Cancel",
-                  admin_assessors_path,
+                  admin_assessors_path(search: params[:search], page: params[:page]),
                   class: 'govuk-button govuk-button--secondary'
     - if action_name == "edit" && policy(resource).destroy?
-      = link_to 'Delete', admin_assessor_path(resource), data: { method: :delete, confirm: 'Are you sure you want to delete this user?' }, class: 'govuk-button govuk-button--warning'
+      = link_to 'Delete',
+                admin_assessor_path(resource, search: params[:search], page: params[:page]),
+                data: { method: :delete, confirm: 'Are you sure you want to delete this user?' },
+                class: 'govuk-button govuk-button--warning'

--- a/app/views/admin/assessors/_list.html.slim
+++ b/app/views/admin/assessors/_list.html.slim
@@ -28,7 +28,7 @@ div role="region" aria-labelledby="table-list-national-assessors-caption" tabind
           tr.govuk-table__row
             th.govuk-table__header scope="row"
               = link_to assessor.full_name,
-                        edit_admin_assessor_path(assessor),
+                        edit_admin_assessor_path(assessor, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         aria: { label: "edit #{ assessor.full_name }"}
             td.govuk-table__cell = assessor.sub_group&.text
@@ -55,7 +55,7 @@ div role="region" aria-labelledby="table-list-national-assessors-caption" tabind
                   ' Not locked
             td.govuk-table__cell
               = link_to "Edit user",
-                        edit_admin_assessor_path(assessor),
+                        edit_admin_assessor_path(assessor, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         id: "edit #{ assessor.first_name.downcase } #{ assessor.last_name.downcase }",
                         aria: { label: "edit #{ assessor.full_name }"}

--- a/app/views/admin/assessors/edit.html.slim
+++ b/app/views/admin/assessors/edit.html.slim
@@ -1,7 +1,9 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to users list",
+            admin_assessors_path(search: params[:search], page: params[:page]),
+            class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")

--- a/app/views/admin/assessors/new.html.slim
+++ b/app/views/admin/assessors/new.html.slim
@@ -1,7 +1,9 @@
 - title t("admin.users.new_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to users list",
+            admin_assessors_path(search: params[:search], page: params[:page]),
+            class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.new_button.#{controller_name}")

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -5,10 +5,10 @@
       td.govuk-table__cell = check_box_tag "check_#{obj.id}", obj.id, false, class: "form-answer-check", aria: { label: "Select nomination #{obj.id} for bulk action" }
     td.td-title.govuk-table__cell
       - if obj.company_or_nominee_name.present?
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]), aria: { label: "View submitted nomination for #{obj.company_or_nominee_name}" }, class: 'govuk-link' do
           = obj.company_or_nominee_name
       - else
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]), aria: { label: "View submitted nomination, nominee name not yet specified" }, class: 'govuk-link' do
           em
             ' Not yet specified
     td.govuk-table__cell = obj.dashboard_status
@@ -35,5 +35,5 @@
           = obj.last_updated_by
     td.govuk-table__cell
       - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
-      = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+      = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]), aria: { label: aria_label }, class: 'govuk-link' do
         | View

--- a/app/views/admin/form_answers/show.html.slim
+++ b/app/views/admin/form_answers/show.html.slim
@@ -1,5 +1,5 @@
 - content_for :before_main_content do
-  = link_to "Back to nominations list", admin_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
+  = link_to "Back to nominations list", admin_form_answers_path(search_id: params[:search_id], year: params[:year], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = resource.nominee_name

--- a/app/views/admin/group_leaders/_form.html.slim
+++ b/app/views/admin/group_leaders/_form.html.slim
@@ -1,4 +1,7 @@
-= simple_form_for [:admin, resource], as: :group_leader, url: admin_group_leader_path(resource), html: { class: 'qae-form' } do |f|
+= simple_form_for [:admin, resource],
+                  as: :group_leader,
+                  url: admin_group_leader_path(resource, search: params[:search], page: params[:page]),
+                  html: { class: 'qae-form' } do |f|
   = render "shared/users/user_details", f: f
 
   - if f.object.persisted?
@@ -9,8 +12,11 @@
       = f.submit "#{f.object.persisted? ? 'Update' : 'Add'} user",
                 class: 'govuk-button'
       = link_to "Cancel",
-                admin_group_leaders_path,
+                admin_group_leaders_path(search: params[:search], page: params[:page]),
                 class: 'govuk-button govuk-button--secondary'
 
       - if action_name == "edit" && policy(resource).destroy?
-        = link_to 'Delete', admin_group_leader_path(resource), data: { method: :delete, confirm: 'Are you sure you want to delete this user?' }, class: 'govuk-button govuk-button--warning'
+        = link_to 'Delete',
+                  admin_group_leader_path(resource, search: params[:search], page: params[:page]),
+                  data: { method: :delete, confirm: 'Are you sure you want to delete this user?' },
+                  class: 'govuk-button govuk-button--warning'

--- a/app/views/admin/group_leaders/_list.html.slim
+++ b/app/views/admin/group_leaders/_list.html.slim
@@ -26,7 +26,7 @@ div role="region" aria-labelledby="table-list-group-leaders-caption" tabindex="0
           tr.govuk-table__row
             th.govuk-table__header scope="row"
               = link_to group_leader.full_name,
-                        edit_admin_group_leader_path(group_leader),
+                        edit_admin_group_leader_path(group_leader, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         aria: { label: "Edit #{ group_leader.first_name.downcase } #{ group_leader.last_name.downcase }" }
             td.govuk-table__cell
@@ -52,7 +52,7 @@ div role="region" aria-labelledby="table-list-group-leaders-caption" tabindex="0
                   ' Not locked
             td.govuk-table__cell
               = link_to "Edit user",
-                edit_admin_group_leader_path(group_leader),
+                edit_admin_group_leader_path(group_leader, search: params[:search], page: params[:page]),
                 class: "govuk-link",
                 id: "edit-#{ group_leader.first_name.downcase }-#{ group_leader.last_name.downcase }",
                 aria: { label: "Edit #{ group_leader.first_name.downcase } #{ group_leader.last_name.downcase }" }

--- a/app/views/admin/group_leaders/edit.html.slim
+++ b/app/views/admin/group_leaders/edit.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to group leaders list",
+  = link_to "Back to users list",
             admin_group_leaders_path(search: params[:search], page: params[:page]),
             class: "govuk-back-link"
 

--- a/app/views/admin/group_leaders/edit.html.slim
+++ b/app/views/admin/group_leaders/edit.html.slim
@@ -1,7 +1,9 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to group leaders list",
+            admin_group_leaders_path(search: params[:search], page: params[:page]),
+            class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")

--- a/app/views/admin/lieutenants/_form.html.slim
+++ b/app/views/admin/lieutenants/_form.html.slim
@@ -1,4 +1,7 @@
-= simple_form_for [:admin, resource], as: :lieutenant, url: resource.persisted? ? admin_lieutenant_path(resource) : admin_lieutenants_path, html: { class: 'qae-form' } do |f|
+= simple_form_for [:admin, resource],
+                  as: :lieutenant,
+                  url: resource.persisted? ? admin_lieutenant_path(resource, search: params[:search], page: params[:page]) : admin_lieutenants_path(search: params[:search], page: params[:page]),
+                  html: { class: 'qae-form' } do |f|
   = render "shared/users/user_details", f: f
 
   = f.association :ceremonial_county,
@@ -19,7 +22,10 @@
       = f.submit "#{f.object.persisted? ? 'Update' : 'Add'} user",
                 class: 'govuk-button'
       = link_to "Cancel",
-                admin_lieutenants_path,
+                admin_lieutenants_path(search: params[:search], page: params[:page]),
                 class: 'govuk-button govuk-button--secondary'
       - if action_name == "edit" && policy(resource).destroy?
-        = link_to 'Delete user', admin_lieutenant_path(resource), data: { method: :delete, confirm: 'Are you sure you want to delete this user?' }, class: 'govuk-button govuk-button--warning'
+        = link_to 'Delete user',
+                  admin_lieutenant_path(resource, search: params[:search], page: params[:page]),
+                  data: { method: :delete, confirm: 'Are you sure you want to delete this user?' },
+                  class: 'govuk-button govuk-button--warning'

--- a/app/views/admin/lieutenants/_list.html.slim
+++ b/app/views/admin/lieutenants/_list.html.slim
@@ -41,7 +41,7 @@ div role="region" aria-labelledby="table-list-lieutenancy-office-caption" tabind
             - else
               th.govuk-table__header scope="row"
                 = link_to lieutenant.full_name,
-                  edit_admin_lieutenant_path(lieutenant),
+                  edit_admin_lieutenant_path(lieutenant, search: params[:search], page: params[:page]),
                   class: "govuk-link",
                   aria: { label: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }
             td.govuk-table__cell
@@ -71,13 +71,13 @@ div role="region" aria-labelledby="table-list-lieutenancy-office-caption" tabind
                   ' Not locked
             td.govuk-table__cell
               - if action_name == "deleted"
-                = link_to "Restore user", restore_admin_lieutenant_path(lieutenant),
+                = link_to "Restore user", restore_admin_lieutenant_path(lieutenant, search: params[:search], page: params[:page]),
                           class: "govuk-link",
                           id: "restore-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }",
                           method: :post,
                           aria: { label: "restore-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }
               - else
-                = link_to "Edit user", edit_admin_lieutenant_path(lieutenant),
+                = link_to "Edit user", edit_admin_lieutenant_path(lieutenant, search: params[:search], page: params[:page]),
                           class: "govuk-link",
                           id: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }",
                           aria: { label: "edit-#{ lieutenant.first_name.downcase }-#{ lieutenant.last_name.downcase }" }

--- a/app/views/admin/lieutenants/edit.html.slim
+++ b/app/views/admin/lieutenants/edit.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to lieutenants list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
+  = link_to "Back to users list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")

--- a/app/views/admin/lieutenants/edit.html.slim
+++ b/app/views/admin/lieutenants/edit.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to lieutenants list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")

--- a/app/views/admin/lieutenants/new.html.slim
+++ b/app/views/admin/lieutenants/new.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to lieutenants list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
+  = link_to "Back to users list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.new_button.#{controller_name}")

--- a/app/views/admin/lieutenants/new.html.slim
+++ b/app/views/admin/lieutenants/new.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to lieutenants list", admin_lieutenants_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.new_button.#{controller_name}")

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,4 +1,7 @@
-= simple_form_for [:admin, resource], html: { class: "qae-form" } do |f|
+= simple_form_for [:admin, resource],
+  as: :user,
+  url: resource.persisted? ? admin_user_path(resource, search: params[:search], page: params[:page]) : admin_users_path(search: params[:search], page: params[:page]),
+  html: { class: "qae-form" } do |f|
   = render "fields_user_details", f: f
 
   .govuk-button-group
@@ -25,5 +28,5 @@
                 method: :patch
 
     = link_to "Cancel",
-              admin_users_path,
+              admin_users_path(search: params[:search], page: params[:page]),
               class: "govuk-button govuk-button--secondary btn-default btn-md"

--- a/app/views/admin/users/_list.html.slim
+++ b/app/views/admin/users/_list.html.slim
@@ -26,7 +26,7 @@ div role="region" aria-labelledby="table-list-nominators-caption" tabindex="0"
           tr.govuk-table__row
             th.govuk-table__header scope="row"
               = link_to user.full_name,
-                        edit_admin_user_path(user),
+                        edit_admin_user_path(user, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         aria: { label: "edit #{ user.full_name }" }
             td.govuk-table__cell
@@ -54,6 +54,6 @@ div role="region" aria-labelledby="table-list-nominators-caption" tabindex="0"
                   ' Not locked
             td.govuk-table__cell
               = link_to "Edit user",
-                        edit_admin_user_path(user),
+                        edit_admin_user_path(user, search: params[:search], page: params[:page]),
                         class: "govuk-link",
                         aria: { label: "edit #{ user.full_name }" }

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.edit_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to users list", admin_users_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.edit_button.#{controller_name}")

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -33,7 +33,7 @@
                         role: "button",
                         aria: { label: "Show deleted users" }
 
-          = link_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user govuk-button pull-right', role: 'button' do
+          = link_to public_send("new_admin_#{controller_name.singularize}_path", search: params[:search], page: params[:page]), class: 'new-user govuk-button pull-right', role: 'button' do
             = t("admin.users.new_button.#{controller_name}")
         .clear
 

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,7 +1,7 @@
 - title t("admin.users.new_button.#{controller_name}")
 
 - content_for :before_main_content do
-  = link_to "Back to users list", admin_users_path, class: "govuk-back-link"
+  = link_to "Back to users list", admin_users_path(search: params[:search], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = t("admin.users.new_button.#{controller_name}")

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -2,7 +2,7 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]), class: 'govuk-link' do
           - unless obj.nominee_name.nil?
             span
               = obj.nominee_name
@@ -33,5 +33,5 @@ tbody.govuk-table__body
 
       td.govuk-table__cell
         - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]), aria: { label: aria_label }, class: 'govuk-link' do
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]), aria: { label: aria_label }, class: 'govuk-link' do
           | View

--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -1,5 +1,5 @@
 -content_for :before_main_content do
-  = link_to "Back to nominations list", assessor_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
+  = link_to "Back to nominations list", assessor_form_answers_path(search_id: params[:search_id], year: params[:year], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = @form_answer.nominee_name

--- a/app/views/lieutenant/form_answers/_list_body.html.slim
+++ b/app/views/lieutenant/form_answers/_list_body.html.slim
@@ -2,12 +2,12 @@ tbody.govuk-table__body
   - FormAnswerDecorator.decorate_collection(@form_answers).each do |obj|
     tr.govuk-table__row
       th.govuk-table__header scope="row"
-        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year]),
+        = link_to polymorphic_url([namespace_name, obj], search_id: params[:search_id], year: params[:year], page: params[:page]),
                   aria: { label: "View submitted nomination, for #{obj.company_or_nominee_name}" },
                   class: 'govuk-link' do
           span
             = obj.nominee_name
-          
+
       td.govuk-table__cell = obj.dashboard_status
 
       td.govuk-table__cell = obj.document["nominee_address_postcode"]
@@ -26,6 +26,6 @@ tbody.govuk-table__body
 
       td.govuk-table__cell
         = link_to "View",
-                  lieutenant_form_answer_path(obj, search_id: params[:search_id], year: params[:year]),
+                  lieutenant_form_answer_path(obj, search_id: params[:search_id], year: params[:year], page: params[:page]),
                   aria: { label: "View submitted nomination, for #{obj.company_or_nominee_name}" },
                   class: 'govuk-link'

--- a/app/views/lieutenant/form_answers/show.html.slim
+++ b/app/views/lieutenant/form_answers/show.html.slim
@@ -1,7 +1,7 @@
 - title "#{resource.nominee_name} nomination"
 
 - content_for :before_main_content do
-  = link_to "Back to nominations list", lieutenant_form_answers_path(search_id: params[:search_id], year: params[:year]), class: "govuk-back-link"
+  = link_to "Back to nominations list", lieutenant_form_answers_path(search_id: params[:search_id], year: params[:year], page: params[:page]), class: "govuk-back-link"
 
 h1.govuk-heading-xl
   = resource.nominee_name


### PR DESCRIPTION
## 📝 A short description of the changes

* We would like to retain search or page results navigating back after viewing users and nominations. To do this we permit search params in the admin user controllers and pass the params when navigating/using controller methods.
* The changes are applied to nominations tables and admin user tables (users, lieutenants, assessors, group leaders and admins)
* Back to users breadcrumb has been updated to return the admin to the relevant user path instead of always returning to nominators table.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206580439748049

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

