### PR TITLE
Adds statuses to assessor assignments

### DIFF
--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -36,7 +36,7 @@ class Assessor::FormAnswersController < Assessor::BaseController
 
     scope = current_assessor.applications_scope(
       params[:year].to_s == "all_years" ? nil : @award_year
-    ).eligible_for_assessor
+    ).includes(:assessor_assignments).eligible_for_assessor
 
     if search_params[:query].blank? && category_picker.show_award_tabs_for_assessor?
       scope = scope.where(award_type: category_picker.current_award_type)
@@ -95,13 +95,17 @@ class Assessor::FormAnswersController < Assessor::BaseController
   def edit
     authorize resource, :edit?
 
+    unless assessor_assignment.status
+      assessor_assignment.update(status: "viewed")
+    end
+
     @form = resource.award_form.decorate(answers: HashWithIndifferentAccess.new(resource.document))
   end
 
   private
 
   def resource
-    @form_answer ||= current_assessor.applications_scope(@award_year).find(params[:id]).decorate
+    @form_answer ||= current_assessor.applications_scope(@award_year).includes(:assessor_assignments).find(params[:id]).decorate
   end
 
   def category_picker
@@ -119,5 +123,10 @@ class Assessor::FormAnswersController < Assessor::BaseController
     else
       "application-assessor"
     end
+  end
+
+  def assessor_assignment
+    AssessorAssignment.find_by(assessor_id: current_assessor.id, form_answer_id: resource.id) ||
+    resource.assessor_assignments.build(assessor: current_assessor, award_year: @award_year)
   end
 end

--- a/app/services/assessor_assignment_service.rb
+++ b/app/services/assessor_assignment_service.rb
@@ -14,6 +14,7 @@ class AssessorAssignmentService
     resource.assign_attributes(update_params)
     resource.editable = current_subject
     resource.assessed_at = DateTime.now unless assignment_request?
+    resource.status = "in_progress"
     resource.save
   end
 

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -10,11 +10,6 @@ tbody.govuk-table__body
             em
               ' Not found
 
-      td.govuk-table__cell = obj.dashboard_status
-
-      td.govuk-table__cell
-        = obj.sub_group.try(:text) || "Not assigned"
-
       td.govuk-table__cell
         - if obj.ceremonial_county.present?
           = obj.ceremonial_county.name
@@ -30,6 +25,18 @@ tbody.govuk-table__body
         br
         span.muted
           = obj.last_updated_by
+
+      td.govuk-table__cell
+        - assignment = obj.assessor_assignments.detect{|aa| aa.assessor_id == current_assessor.id}
+        - if assignment&.submitted_at
+          strong.govuk-tag.govuk-tag--green
+            | Submitted
+        - elsif assignment&.status == "in_progress"
+          strong.govuk-tag.govuk-tag--yellow
+            | In progress
+        - elsif assignment&.status == "viewed"
+          strong.govuk-tag.govuk-tag--blue
+            | Viewed
 
       td.govuk-table__cell
         - aria_label = obj.company_or_nominee_name.present? ? "View submitted nomination, for #{obj.company_or_nominee_name}" : "View submitted nomination, nominee name not yet specified"

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -27,7 +27,7 @@ tbody.govuk-table__body
           = obj.last_updated_by
 
       td.govuk-table__cell
-        - assignment = obj.assessor_assignments.detect{|aa| aa.assessor_id == current_assessor.id}
+        - assignment = obj.assessor_assignments.detect { |aa| aa.assessor_id == current_assessor.id }
         - if assignment&.submitted_at
           strong.govuk-tag.govuk-tag--green
             | Submitted

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -46,16 +46,14 @@ h1.govuk-heading-xl
         tr.govuk-table__row
           th.sortable.govuk-table__header scope="col" width="250"
             = sort_link f, "Group name", @search, :company_or_nominee_name, disabled: @search.query?
-          th.govuk-table__header scope="col" width="250"
-            | Status
-          th.govuk-table__header scope="col" width="200"
-            | National assessor Sub-group
           th.govuk-table__header scope="col" width="200"
             | Lord Lieutenancy assigned
           th.govuk-table__header scope="col" width="200"
             | Type of group
           th.sortable.govuk-table__header scope="col" width="130"
             = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
+          th.govuk-table__header scope="col" width="150"
+            | Status
           th.govuk-table__header scope="col" View
         = render(partial: "list_body")
 

--- a/db/migrate/20240216144428_add_status_to_assessor_assignments.rb
+++ b/db/migrate/20240216144428_add_status_to_assessor_assignments.rb
@@ -1,0 +1,5 @@
+class AddStatusToAssessorAssignments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :assessor_assignments, :status, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3838,5 +3838,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211013073349'),
 ('20211104074415'),
 ('20211214111643');
-
-


### PR DESCRIPTION
## 📝 A short description of the changes

* Removes status column and sub group column from assessors form answer table
* Adds a new column to display status of assessment - column shows status tabs for 'Viewed', 'In progress' and 'Submitted'
* Adds a status column to the AssessorAssignments table in the database.
* 'Viewed' will display after the assessor has viewed the application using the buttons on the summary page. These use the edit method in form_answers controller so if status is not yet set, the status will be updated to 'viewed'. AssessorAssignments may not be created at this stage so we check and create if it doesn't exist.
* 'In progress' will display after the assessor has edited the assessment form. This is the 'save' action in the AssessorAssignment controller and changes the status to 'in_progress'. There are no changes to the status after this.
* 'Submitted' will display after the assessor has submitted the assessment and reads from the 'submitted_at' column.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1206580439748056

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1054" alt="Screenshot 2024-02-20 at 11 46 16" src="https://github.com/bitzesty/qavs-v2/assets/65811538/4c8cf90c-21d3-4019-b640-1864f11aa1bc">
