### PR TITLE
Remove npm from Dockerfile because conflict versions - nodejs already has npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 RUN apt-get update
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs npm
+RUN apt-get install -y nodejs
 RUN npm install yarn -g
 
 # ENV SSL_CERT_DIR=/etc/ssl/certs


### PR DESCRIPTION


## 📝 A short description of the changes

Remove npm from Dockerfile because conflict versions - nodejs already has npm

## 🔗 Link to the relevant story (or stories)

* 

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

