### PR TITLE
Build support letters if none are present in non-JS version

### DIFF
--- a/app/views/form/support_letters/_form.html.slim
+++ b/app/views/form/support_letters/_form.html.slim
@@ -15,8 +15,9 @@
 
         = ff.simple_fields_for :support_letter_attachment, (ff.object.support_letter_attachment || ff.object.build_support_letter_attachment)  do |fff|
           = fff.input :attachment, as: :file, label: "Upload Letter of Support #{idx}", input_html: { class: "form-control" }, wrapper_html: { style: "margin-bottom: -1rem;" }
-          p.govuk-body.support-letter-attachment-filename
-            = render "shared/attachment_with_virus_check_status", item: fff.object, mount_name: :attachment
+          - if fff.object.attachment.present?
+            p.govuk-body.support-letter-attachment-filename
+              = render "shared/attachment_with_virus_check_status", item: fff.object, mount_name: :attachment
 
           = fff.input :attachment_cache, as: :hidden
 

--- a/app/views/form/supporters/index.html.slim
+++ b/app/views/form/supporters/index.html.slim
@@ -40,6 +40,9 @@ h1.govuk-heading-xl
           = simple_form_for [:form, @form_answer], url: [:form, @form_answer, :support_letters], method: :post, data: { turbo: false }, html: { class: 'qae-form' } do |f|
             = hidden_field_tag :current_step_id, @step.title_to_param
             = hidden_field_tag :next_step_id, @step.next.title_to_param
+
+            - 2.times do |n|
+              - f.object.support_letters.build unless f.object.support_letters[n].present?
             
             ul.list-add.supporters-list
               = render partial: "form/support_letters/form", locals: { f: f }


### PR DESCRIPTION
## 📝 A short description of the changes

Related to #697 

- build `SuportLetter` association if none exist

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1199154381249427/1206750664011265/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

