### PR TITLE
Disables ckeditor version warning

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -951,6 +951,7 @@ jQuery ->
         height: 200
         wordcount:
           maxWordCount: $(this).data('word-max')
+        versionCheck: false
 
       CKEDITOR.on 'instanceCreated', (event) ->
         editor = event.editor

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,3 +1,3 @@
 Ckeditor.setup do |config|
-  config.cdn_url = "//cdn.ckeditor.com/4.16.2/full/ckeditor.js"
+  config.cdn_url = "//cdn.ckeditor.com/4.22.1/full/ckeditor.js"
 end


### PR DESCRIPTION
Signed-off-by: Louis Kirkham <louis.kirkham@bitzesty.com>

## 📝 A short description of the changes

* This PR disables the warning for the CK editor warning. It is a temporary fix to hide the warning from users while we apply a major upgrade to CKeditor.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1207754952747949/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

