### PR TITLE
Fix: Statistics table QA amendments

### DIFF
--- a/app/views/admin/statistics/nomination_mailer/notify.text.erb
+++ b/app/views/admin/statistics/nomination_mailer/notify.text.erb
@@ -2,11 +2,9 @@ Dear <%= @admin.first_name %>,
 
 You requested an export of nomination statistics.
 
-Please find this report on the link below: 
+Please find this report on the link below:
 <%= admin_protected_file_url(@file) %>
 
-Kind Regards,
+Kind regards,
 
 The King's Awards Office
-
-

--- a/app/views/admin/statistics/nominations/index.html.slim
+++ b/app/views/admin/statistics/nominations/index.html.slim
@@ -12,7 +12,7 @@ h1.govuk-heading-xl
             ' Award year
           = g.select :year, award_years_collection, {}, { id: "award-year-select", class: "govuk-select custom-select", style: "height: 40px;", aria: { label: "award year select" } }
 
-      = render "shared/form_answers/filters/assigned_lieutenancy_filter", g: g, options: NominationStatsSearch.ceremonial_county_options
+      = render "shared/form_answers/filters/assigned_lieutenancy_filter", g: g, options: FormAnswerStatus::AdminFilter.collection('assigned county')
 
   div[class="govuk-button-group"]
     = f.submit "Apply filters",


### PR DESCRIPTION
## 📝 A short description of the changes

Some minor fixes to the new statistic table feature
* Default search was not returning the Not Assigned row so we have reverted back to the shared AdminFilter that is used for other Lieutenancy filters.
* Uses 'Not Assigned' for the unassigned row
* Copy change on the email

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208124592841642/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

