### PR TITLE
Letters of support - non-js and js validation fixes

### DIFF
--- a/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
@@ -35,6 +35,7 @@ window.SupportLetters =
       textContainer.find('.flex').html('<p class="govuk-body">' + filename + '</p>')
       hiddenInput = $("<input class='js-support-letter-attachment-id' type='hidden' name='#{$el.attr("name")}' value='#{data.result['id']}' />")
       parent.append(hiddenInput)
+      parent.find('.js-support-letter-attachment').addClass('govuk-!-display-none')
       SupportLetters.autosave()
       SupportLetters.submit(e)
 

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -56,6 +56,9 @@ window.FormValidation =
   isCheckboxQuestion: (question) ->
     question.find("input[type='checkbox']").length
 
+  isSupportLetterAttachment: (question) ->
+    question.find(".js-support-letter-attachment").length
+
   toDate: (str) ->
     moment(str, "DD/MM/YYYY")
 
@@ -80,6 +83,9 @@ window.FormValidation =
 
       if @isCheckboxQuestion(question)
         return question.find("input[type='checkbox']").filter(":checked").length
+
+      if @isSupportLetterAttachment(question)
+        return (question.find(".js-support-letter-attachment-id").val() || '').toString().trim().length
 
   validateRequiredQuestion: (question) ->
     # if it's a conditional question, but condition was not satisfied
@@ -352,13 +358,6 @@ window.FormValidation =
       @addErrorMessage(question, errorMessage)
       return
 
-  validateSupportLetters: (question) ->
-    lettersReceived = $(".js-support-letter-received").length
-    if lettersReceived < 2
-      @logThis(question, "validateSupportLetters", "Upload two letters of support")
-      @appendMessage(question, "Upload two letters of support")
-      @addErrorClass(question)
-
   validateSelectionLimit: (question) ->
     selection_limit = question.data("selection-limit")
     current_selection_count = question.find("input[type=checkbox]:checked").length
@@ -454,11 +453,6 @@ window.FormValidation =
     if question.hasClass("js-conditional-drop-block-answer")
       # console.log "validateDropBlockCondition"
       @validateDropBlockCondition(question)
-
-    if question.hasClass("question-support-requests") ||
-       question.hasClass("question-support-uploads")
-      # console.log "validateSupportLetters"
-      @validateSupportLetters(question)
 
     if question.hasClass("question-limited-selections")
       @validateSelectionLimit(question)

--- a/app/views/form/support_letters/_form.html.slim
+++ b/app/views/form/support_letters/_form.html.slim
@@ -35,16 +35,17 @@
         ' If you upload the wrong file, click the 'Remove' link next to the file name to delete it. The file upload button will reappear, allowing you to select the correct file.
 
       = ff.simple_fields_for :support_letter_attachment, (ff.object.support_letter_attachment || ff.object.build_support_letter_attachment)  do |fff|
-        - if ff.object.support_letter_attachment.present?
+
+        - if ff.object.support_letter_attachment.id.present?
           p.govuk-body.support-letter-attachment-container class="govuk-!-font-size-19"
             = render "shared/attachment_with_virus_check_status", item: fff.object, mount_name: :attachment
             - if ff.object.support_letter_attachment.id.present?
               = link_to 'Remove', form_form_answer_support_letter_support_letter_attachment_path(@form_answer, ff.object, ff.object.support_letter_attachment), method: :delete, class: 'govuk-link non-js-remove-support-letter-attachment govuk-!-font-size-19'
 
-          = fff.input :attachment_cache, as: :hidden
+        = fff.input :attachment_cache, as: :hidden
 
-          = fff.input :form_answer_id, as: :hidden, input_html: { value: @form_answer.id }
-          = fff.input :user_id, as: :hidden, input_html: { value: current_user.id }
+        = fff.input :form_answer_id, as: :hidden, input_html: { value: @form_answer.id }
+        = fff.input :user_id, as: :hidden, input_html: { value: current_user.id }
 
         - unless fff.object.id.present?
           = fff.input :attachment, as: :file, label: false, input_html: { class: "form-control" }, wrapper_html: { style: "margin-bottom: -1rem;" }

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -48,5 +48,4 @@ li.borderless[class=class_names("js-add-example", "js-support-letter-received" =
       ' If you upload the wrong file, click the 'Remove' link next to the file name to delete it. The file upload button will reappear, allowing you to select the correct file.
     span.govuk-error-message
     input class="js-support-letter-field js-trigger-autosave js-support-letter-attachment govuk-input medium #{'govuk-!-display-none' if supporter['letter_of_support'].present?}" name="form[#{question.key}][#{index}][letter_of_support]" id="form[#{question.key}][#{index}][letter_of_support]" type='file' *possible_read_only_ops(question.step.opts[:id])
-    - if supporter['letter_of_support'].present?
-      = render "support_letters/attachment", question: question, index: index, supporter: supporter, attachment_id: supporter['letter_of_support']
+    = render "support_letters/attachment", question: question, index: index, supporter: supporter, attachment_id: supporter['letter_of_support']

--- a/app/views/support_letters/_attachment.html.slim
+++ b/app/views/support_letters/_attachment.html.slim
@@ -1,6 +1,6 @@
 - file = support_letter_attachments[attachment_id.to_i]
 
-.support-letter-attachment-container
+.support-letter-attachment-container class="#{'govuk-!-display-none' unless attachment_id.present?}"
   .flex
     .support-letter-attachment-filename class="govuk-!-font-size-19"
       = render "shared/attachment_with_virus_check_status", item: file, mount_name: :attachment


### PR DESCRIPTION
## 📝 A short description of the changes

* Remove validation for old letters of support question. This checks if 2 upload blocks have been filled in and adds an overarching error, we now use individual errors beside each input.
* Hide file upload input after successful upload.
* Fix js & non-js validation for support letter attachments.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208016917079089/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

