### PR TITLE
Letters of support - form UI tweaks

### DIFF
--- a/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
@@ -32,7 +32,8 @@ window.SupportLetters =
       
       textContainer = parent.find('.support-letter-attachment-container')
       textContainer.removeClass('govuk-!-display-none')
-      textContainer.find('.flex').html('<p class="govuk-body">' + filename + '</p>')
+      scanningText = '<p class="govuk-hint">(File uploaded and is being scanned for viruses. Preview available once the scan is complete.)</p>'
+      textContainer.prepend('<div class="support-letter-attachment-filename"><p class="govuk-body">' + filename + '</p>' + scanningText + '</div>')
       hiddenInput = $("<input class='js-support-letter-attachment-id' type='hidden' name='#{$el.attr("name")}' value='#{data.result['id']}' />")
       parent.append(hiddenInput)
       parent.find('.js-support-letter-attachment').addClass('govuk-!-display-none')

--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -164,12 +164,6 @@ label > .visible-read-only,
   align-items: start;
   background: $govuk-light-grey;
 
-  .flex {
-    display: flex;
-    justify-content: space-between;
-    align-items: start;
-  }
-
   .js-remove-support-letter-attachment{
     color: $govuk-red;
     word-break: keep-all;

--- a/app/views/form/support_letters/_form.html.slim
+++ b/app/views/form/support_letters/_form.html.slim
@@ -13,7 +13,7 @@
         = render "qae_form/question_ref", question: question, ref: "C #{idx}.1"
       span[class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"]
         = "Name of the person who wrote the #{first_or_second} letter of support"
-      = ff.input :first_name, label: "First Name:", input_html: { class: "form-control medium" }
+      = ff.input :first_name, label: "First name:", input_html: { class: "form-control medium" }
       = ff.input :last_name, label: "Surname:", input_html: { class: "form-control medium" }
 
       legend.govuk-label aria-label="C #{idx}.2: Relationship to Group"

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -31,7 +31,7 @@
 
     <%= stylesheet_pack_tag 'application' %>
 
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= image_url('favicon.ico') %>]" type="image/x-icon">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= image_url('favicon.ico') %>" type="image/x-icon">
     <link rel="mask-icon" href="<%= image_url('govuk-mask-icon.svg') %>]" color="blue">
     <link rel="apple-touch-icon" sizes="180x180" href="<%= image_url('govuk-apple-touch-icon-180x180.png') %>]">
     <link rel="apple-touch-icon" sizes="167x167" href="<%= image_url('govuk-apple-touch-icon-167x167.png') %>]">

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -20,7 +20,7 @@ li.borderless[class=class_names("js-add-example", "js-support-letter-received" =
       ' Name of the person who wrote the #{first_or_second} letter of support
   .govuk-form-group.question-block.question-required
     label.govuk-label for="form[#{question.key}][#{index}][first_name]"
-      ' First Name:
+      ' First name:
     span.govuk-error-message
     input.js-support-letter-field.js-support-letter-first-name.js-trigger-autosave.govuk-input autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][first_name]" id="form[#{question.key}][#{index}][first_name]" type="text" value=supporter["first_name"] *possible_read_only_ops(question.step.opts[:id])
   .govuk-form-group.question-block.question-required

--- a/app/views/support_letters/_attachment.html.slim
+++ b/app/views/support_letters/_attachment.html.slim
@@ -1,9 +1,8 @@
 - file = support_letter_attachments[attachment_id.to_i]
 
 .support-letter-attachment-container class="#{'govuk-!-display-none' unless attachment_id.present?}"
-  .flex
-    .support-letter-attachment-filename class="govuk-!-font-size-19"
-      = render "shared/attachment_with_virus_check_status", item: file, mount_name: :attachment
+  .support-letter-attachment-filename class="govuk-body govuk-!-font-size-19"
+    = render "shared/attachment_with_virus_check_status", item: file, mount_name: :attachment
   button.govuk-link.js-remove-support-letter-attachment class="govuk-!-font-size-19" data-module="govuk-button" type="button"
     | Remove
 input.js-support-letter-attachment-id type="hidden" name="form[#{question.key}][#{index}][letter_of_support]" value=attachment_id *possible_read_only_ops


### PR DESCRIPTION
## 📝 A short description of the changes

- Show status of attachment when first uploaded.
- Correct file name styling to govuk-body.
- Update first name label on support letters form.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208164465455881/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="581" alt="Screenshot 2024-08-29 at 10 44 36 AM" src="https://github.com/user-attachments/assets/e495ae42-5838-4e7f-85df-167a1c51ff49">


