### PR TITLE
Update how form answer PDFs are rendered for supporters question

### DIFF
--- a/app/helpers/form_answer_helper.rb
+++ b/app/helpers/form_answer_helper.rb
@@ -86,4 +86,13 @@ module FormAnswerHelper
   def show_bulk_lieutenants_assignment?
     policy(:lieutenant_assignment_collection).create?
   end
+
+  def ordinal_label(index)
+    case index
+    when 0
+      "first"
+    when 1
+      "second"
+    end
+  end
 end

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
@@ -1,4 +1,5 @@
 module QaePdfForms::CustomQuestions::SupporterLists
+  include FormAnswerHelper
   def render_supporters
     entries = form_answer.support_letters.manual
 
@@ -9,31 +10,41 @@ module QaePdfForms::CustomQuestions::SupporterLists
 
   def render_supporters_list(entries)
     entries.each_with_index do |entry, index|
-      entry_index = index == 0 ? "first" : "second"
       ops = [
-        { title: "name_of_the_person_who_wrote_the_#{entry_index}_letter_of_support".to_sym, value: ''},
+        { ref: "C #{index + 1}.1.", title: "name_of_the_person_who_wrote_the_#{ordinal_label(index)}_letter_of_support".to_sym, value: ''},
         { sub_field: "first_name".to_sym, value: entry.first_name },
         { sub_field: "last_name".to_sym, value: entry.last_name },
-        { title: "relationship_to_nominee".to_sym, value: entry.relationship_to_nominee, hint: "For example, a beneficiary of the group, local resident or member of a partner charity." },
+        { ref: "C #{index + 1}.2.", title: "relationship_to_nominee".to_sym, value: entry.relationship_to_nominee, hint: "For example, a beneficiary of the group, local resident or member of a partner charity." },
       ]
 
-      render_supporter(entry, ops, entry_index)
+      render_supporter(entry, ops, index)
     end
   end
 
-  def render_supporter(entry, ops, entry_index)
-    form_pdf.move_down 5.mm
+  def render_supporter(entry, ops, index)
+    form_pdf.text "C #{index + 1}.", style: :bold
+    form_pdf.move_cursor_to form_pdf.cursor + 5.mm
+    form_pdf.indent(13.mm) { form_pdf.text "The #{ordinal_label(index)} letter of support", style: :bold }
+    form_pdf.move_down 2.5.mm
 
     ops.each do |op|
-      form_pdf.text "#{format_label(op[:title])}: ", style: :bold if op[:title]
-      form_pdf.text "#{format_label(op[:sub_field])}: " if op[:sub_field]
-      form_pdf.text(op[:hint], style: :italic) if op[:hint]
-      form_pdf.text op[:value]
-      form_pdf.move_down 2.5.mm
+      if op[:ref]
+        form_pdf.text op[:ref], style: :bold
+        form_pdf.move_cursor_to form_pdf.cursor + 10.mm
+        form_pdf.indent(13.mm) { form_pdf.render_text format_label(op[:title]), style: :bold } if op[:title]
+        form_pdf.indent(13.mm) { form_pdf.render_text op[:hint], style: :italic } if op[:hint]
+        form_pdf.indent(13.mm) { form_pdf.render_text op[:value] }
+      else
+        form_pdf.indent 16.mm do
+          form_pdf.render_text format_label(op[:sub_field])
+          form_pdf.render_text op[:value]
+        end
+      end
+      form_pdf.move_down 5.mm
     end
 
     if entry.is_a?(SupportLetter)
-      render_support_letter(entry, entry_index)
+      render_support_letter(entry, index)
     end
   end
 
@@ -41,16 +52,19 @@ module QaePdfForms::CustomQuestions::SupporterLists
     text.to_s.split('_').join(' ').capitalize
   end
 
-  def render_support_letter(entry, entry_index)
-    form_pdf.text "Upload the #{entry_index} letter of support: ", style: :bold
+  def render_support_letter(entry, index)
+    form_pdf.text "C #{index + 1}.3. Upload the #{ordinal_label(index)} letter of support: ", style: :bold
+    form_pdf.move_down 2.5.mm
 
     if entry.support_letter_attachment.present?
-      form_pdf.base_link_sceleton(
-        form_pdf.attachment_path(entry.support_letter_attachment.attachment, true),
+      form_pdf.indent 12.mm do
+        form_pdf.base_link_sceleton(
+          form_pdf.attachment_path(entry.support_letter_attachment.attachment, true),
         entry.support_letter_attachment.original_filename.truncate(60)
-      )
+        )
+      end
     end
 
-    form_pdf.move_down 2.5.mm
+    form_pdf.move_down 5.mm
   end
 end

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
@@ -8,32 +8,41 @@ module QaePdfForms::CustomQuestions::SupporterLists
   end
 
   def render_supporters_list(entries)
-    entries.each do |entry|
-      ops = {
-        full_name: "#{entry.first_name} #{entry.last_name}",
-        relationship_to_nominee: entry.relationship_to_nominee
-      }
+    entries.each_with_index do |entry, index|
+      entry_index = index == 0 ? "first" : "second"
+      ops = [
+        { title: "name_of_the_person_who_wrote_the_#{entry_index}_letter_of_support".to_sym, value: ''},
+        { sub_field: "first_name".to_sym, value: entry.first_name },
+        { sub_field: "last_name".to_sym, value: entry.last_name },
+        { title: "relationship_to_nominee".to_sym, value: entry.relationship_to_nominee, hint: "For example, a beneficiary of the group, local resident or member of a partner charity." },
+      ]
 
-      render_supporter(entry, ops)
+      render_supporter(entry, ops, entry_index)
     end
   end
 
-  def render_supporter(entry, ops)
+  def render_supporter(entry, ops, entry_index)
     form_pdf.move_down 5.mm
 
-    ops.each do |option_title, option_value|
-      form_pdf.text "#{option_title.to_s.split("_").join(" ").capitalize}: ", style: :bold
-      form_pdf.text option_value
+    ops.each do |op|
+      form_pdf.text "#{format_label(op[:title])}: ", style: :bold if op[:title]
+      form_pdf.text "#{format_label(op[:sub_field])}: " if op[:sub_field]
+      form_pdf.text(op[:hint], style: :italic) if op[:hint]
+      form_pdf.text op[:value]
       form_pdf.move_down 2.5.mm
     end
 
     if entry.is_a?(SupportLetter)
-      render_support_letter(entry)
+      render_support_letter(entry, entry_index)
     end
   end
 
-  def render_support_letter(entry)
-    form_pdf.text "Letter of Support: ", style: :bold
+  def format_label(text)
+    text.to_s.split('_').join(' ').capitalize
+  end
+
+  def render_support_letter(entry, entry_index)
+    form_pdf.text "Upload the #{entry_index} letter of support: ", style: :bold
 
     if entry.support_letter_attachment.present?
       form_pdf.base_link_sceleton(

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -382,9 +382,7 @@ class QaePdfForms::General::QuestionPointer
       when QaeFormBuilder::ByYearsQuestion, QaeFormBuilder::OneOptionByYearsQuestion
         render_years_table
       when QaeFormBuilder::SupportersQuestion
-        form_pdf.indent 7.mm do
           render_supporters
-        end
       when QaeFormBuilder::TextareaQuestion
         title = q_visible? && humanized_answer.present? ? humanized_answer : ""
 

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -161,7 +161,8 @@ class QaePdfForms::General::QuestionPointer
   end
 
   def render_question_title_with_ref_or_not
-    if question.delegate_obj.ref.present? || question.delegate_obj.sub_ref.present?
+    if (question.delegate_obj.ref.present? || question.delegate_obj.sub_ref.present?) &&
+       !question.delegate_obj.is_a?(QaeFormBuilder::SupportersQuestion)
       render_question_with_ref
     else
       render_question_without_ref
@@ -169,8 +170,16 @@ class QaePdfForms::General::QuestionPointer
   end
 
   def render_context_and_answer_blocks
+    if question.delegate_obj.is_a?(QaeFormBuilder::SupportersQuestion)
+      form_pdf.indent 11.mm do
+        render_question_context
+        render_question_help_note
+        render_question_hints
+
+        question_answer(question)
+      end
     # for inline questions answer is rendered with the title
-    if RENDER_INLINE_KEYS.exclude?(question.key.to_s)
+    elsif RENDER_INLINE_KEYS.exclude?(question.key.to_s)
       form_pdf.indent 25.mm do
         render_question_context
         render_question_help_note
@@ -382,7 +391,7 @@ class QaePdfForms::General::QuestionPointer
       when QaeFormBuilder::ByYearsQuestion, QaeFormBuilder::OneOptionByYearsQuestion
         render_years_table
       when QaeFormBuilder::SupportersQuestion
-          render_supporters
+        render_supporters
       when QaeFormBuilder::TextareaQuestion
         title = q_visible? && humanized_answer.present? ? humanized_answer : ""
 

--- a/app/views/form/support_letters/_form.html.slim
+++ b/app/views/form/support_letters/_form.html.slim
@@ -1,24 +1,24 @@
 = f.simple_fields_for :support_letters do |ff|
-  - idx = ff.options[:child_index] + 1
-  - first_or_second = idx == 1 ? "first" : "second"
+  - child_index = ff.options[:child_index]
+  - idx = child_index + 1
   li.borderless
     .question-block
       label[class="govuk-label"]
         legend.govuk-label
           = render "qae_form/question_ref", question: question, ref: "C #{idx}"
       span[class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold govuk-!-display-block"]
-        = "The #{first_or_second} letter of support"
+        = "The #{ordinal_label(child_index)} letter of support"
 
       legend.govuk-label aria-label="C #{idx}.1: Name"
         = render "qae_form/question_ref", question: question, ref: "C #{idx}.1"
       span[class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"]
-        = "Name of the person who wrote the #{first_or_second} letter of support"
+        = "Name of the person who wrote the #{ordinal_label(child_index)} letter of support"
       = ff.input :first_name, label: "First name:", input_html: { class: "form-control medium" }
       = ff.input :last_name, label: "Surname:", input_html: { class: "form-control medium" }
 
       legend.govuk-label aria-label="C #{idx}.2: Relationship to Group"
         = render "qae_form/question_ref", question: question, ref: "C #{idx}.2"
-      label for="form_answer_support_letters_attributes_#{ff.options[:child_index]}_relationship_to_nominee" class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+      label for="form_answer_support_letters_attributes_#{child_index}_relationship_to_nominee" class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
         = "Relationship to group"
       span.question-context.question-debug.govuk-hint
         ' For example, a beneficiary of the group, local resident or member of a partner charity.
@@ -29,8 +29,8 @@
 
       legend.govuk-label aria-label="C #{idx}.3: Upload Letter of Support"
         = render "qae_form/question_ref", question: question, ref: "C #{idx}.3"
-      label for="form_answer_support_letters_attributes_#{ff.options[:child_index]}_support_letter_attachment" class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-        = "Upload the #{first_or_second} letter of support"
+      label for="form_answer_support_letters_attributes_#{child_index}_support_letter_attachment" class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+        = "Upload the #{ordinal_label(child_index)} letter of support"
       span.question-context.question-debug.govuk-hint
         ' If you upload the wrong file, click the 'Remove' link next to the file name to delete it. The file upload button will reappear, allowing you to select the correct file.
 

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -1,4 +1,3 @@
-- first_or_second = index == 0 ? "first" : "second"
 - idx = index + 1
 - persisted = supporter["support_letter_id"].present? || supporter["supporter_id"].present?
 - create_url = users_form_answer_support_letters_url(@form_answer)
@@ -9,7 +8,7 @@ li.borderless[class=class_names("js-add-example", "js-support-letter-received" =
     = render "qae_form/question_ref", question: question, ref: "C #{idx}"
   label[class="govuk-label"]
     span[class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold govuk-!-display-block"]
-      = "The #{first_or_second} letter of support"
+      = "The #{ordinal_label(index)} letter of support"
 
   input.js-support-entry-id type="hidden" name="form[#{question.key}][#{index}][support_letter_id]" value=supporter["support_letter_id"] *possible_read_only_ops(question.step.opts[:id])
   .js-system-tag data-new-hidden-input-name="form[#{question.key}][#{index}][support_letter_id]"
@@ -17,7 +16,7 @@ li.borderless[class=class_names("js-add-example", "js-support-letter-received" =
   legend.govuk-label aria-label="C #{index + 1}.1: Name"
     = render "qae_form/question_ref", question: question, ref: "C #{idx}.1"
     span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-      ' Name of the person who wrote the #{first_or_second} letter of support
+      ' Name of the person who wrote the #{ordinal_label(index)} letter of support
   .govuk-form-group.question-block.question-required
     label.govuk-label for="form[#{question.key}][#{index}][first_name]"
       ' First name:
@@ -43,7 +42,7 @@ li.borderless[class=class_names("js-add-example", "js-support-letter-received" =
     = render "qae_form/question_ref", question: question, ref: "C #{idx}.3"
   .govuk-form-group.question-block.question-required
     label class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block" for="form[#{question.key}][#{index}][letter_of_support]"
-      ' Upload the #{first_or_second} letter of support
+      ' Upload the #{ordinal_label(index)} letter of support
     span.question-context.question-debug.govuk-hint
       ' If you upload the wrong file, click the 'Remove' link next to the file name to delete it. The file upload button will reappear, allowing you to select the correct file.
     span.govuk-error-message

--- a/forms/award_years/v2025/qavs/qavs_step3.rb
+++ b/forms/award_years/v2025/qavs/qavs_step3.rb
@@ -22,8 +22,8 @@ class AwardYears::V2025::QaeForms
           pdf_context_with_header_blocks [
             [:normal, %(Letters of support are an essential part of your nomination, as they help to clarify and explain the impact of the nominated group's work in the local community. You will need to provide 2 letters of support alongside your nomination.)],
             [:normal, %(For more information on what letters can cover, please see the <link href="https://kavs.dcms.gov.uk/make-a-nomination/letters-of-support/" target="_blank">Letters of Support page</link> on our website.)],
-            [:bold, %(Key criteria:
-
+            [:bold, %(Key criteria:)],
+            [:normal, %(
               1. Letters must be written by individuals who are familiar with the group's work, for example: a beneficiary, local resident or member of a partner charity.
               2. Letters must not be written by a volunteer, employee, trustee, or anyone involved in the running of the group.
               3. Letters written by the nominator will be ineligible.


### PR DESCRIPTION
## 📝 A short description of the changes

* Letters of support questions are structured as 1 question with 2 entities. The support letters are stored within a supporter_letters_list array:
```
 document:
  {
   "supporter_letters_list"=>
      [
        {"support_letter_id"=>"",
         "first_name"=>"",
         "last_name"=>"",
         "relationship_to_nominee"=>"",
         "letter_of_support"=>""},
       {"support_letter_id"=>"",
         "first_name"=>"",
         "last_name"=>"",
         "relationship_to_nominee"=>"",
         "letter_of_support"=>""}
]...

```

* Because the PDF generator will interpret this as one question, I am 'mocking' the question refs (C 1.1) so that the PDF version of the question looks like this:

**C1. The first letter of support**
**C1.1. Name of the person who wrote the first letter of support**

First name:

Surname:

**C1.2. Relationship to group**
_For example, a beneficiary of the group, local resident or member of a partner charity._

**C1.3. Upload the first letter of support**




## 🔗 Link to the relevant story (or stories)

* 

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

