### PR TITLE
Fix: fixes for bulk assign buttons

### DIFF
--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -54,5 +54,5 @@ $todo-black: #333;
 }
 
 .govuk-notification-banner__heading {
-  max-width: 700px
+  max-width: 100%
 }

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -110,7 +110,7 @@ module FormAnswerMixin
 
       unless @processor.valid?
         flash[:bulk_error] = @processor.base_error_messages
-        redirect_to admin_form_answers_path(year: params[:year], search_id: @processor.search_id) + "#bulk_error" and return
+        redirect_to admin_form_answers_path(year: params[:year], search_id: @processor.search_id, anchor: "bulk_error") and return
       end
 
       redirect_url = @processor.redirect_url

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -120,19 +120,31 @@ module FormAnswerMixin
       end
     end
 
+    # If search is present, save it and clean up the params.
+    # Do not pass params[:year] to the redirect as this does not work with the non-js search
     if params[:search] && params[:search][:search_filter] != FormAnswerSearch.default_search[:search_filter]
       search = NominationSearch.create(serialized_query: params[:search].to_json)
-      redirect_to [namespace_name, :form_answers, search_id: search.id, year: params[:year]] and return
-    end
+      year = JSON.parse(search.serialized_query)[:year]
+      redirect_to [namespace_name, :form_answers, search_id: search.id, year: year] and return
 
-    if params[:search_id]
+    elsif params[:search_id]
       search = NominationSearch.find_by_id(params[:search_id])
-
       if search.present?
         payload = JSON.parse(search.serialized_query)
         search_params[:search_filter] = payload["search_filter"]
         search_params[:query] = payload["query"]
         search_params[:sort] = payload["sort"]
+        search_params[:year] = payload["year"]
+
+        # Update the year parameter if it is different
+        if params[:year] && search_params[:year] != params[:year]
+          search_params[:year] = params[:year]
+          search.update_attribute(:serialized_query, search_params.to_json)
+
+        # Redirect to include the year parameter if it is not present
+        elsif !params[:year] && namespace_name == :admin
+          redirect_to [namespace_name, :form_answers, search_id: search.id, year: search_params[:year]] and return
+        end
       end
     end
 

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -110,7 +110,7 @@ module FormAnswerMixin
 
       unless @processor.valid?
         flash[:bulk_error] = @processor.base_error_messages
-        redirect_to admin_form_answers_path(year: params[:year], search_id: @processor.search_id) and return
+        redirect_to admin_form_answers_path(year: params[:year], search_id: @processor.search_id) + "#bulk_error" and return
       end
 
       redirect_url = @processor.redirect_url

--- a/app/views/admin/form_answers/_bulk_assignment_button_top.html.slim
+++ b/app/views/admin/form_answers/_bulk_assignment_button_top.html.slim
@@ -5,7 +5,7 @@
         ' Bulk actions:
       ' select groups from the list below and click an appropriate bulk action button.
     - if flash[:bulk_error].present?
-      p.govuk-body.govuk-bulk-error-message
+      p.govuk-body.govuk-bulk-error-message#bulk_error
         = flash[:bulk_error]
     .bulk-assignment-buttons-container
       = f.submit "Bulk assign to Lord Lieutenancy office", class: "govuk-button bulk-assign-lieutenants-link", name: "bulk_assign_lieutenants"

--- a/app/views/admin/form_answers/bulk_assign_assessors.html.slim
+++ b/app/views/admin/form_answers/bulk_assign_assessors.html.slim
@@ -1,6 +1,9 @@
 h3.govuk-heading-m
   | Bulk assign groups to national assessor sub-group
 
+.govuk-body
+  | Please select the national assessor sub-group that you would like to assign the selected groups to.
+
 = form_for [namespace_name, @form] do |f|
   .govuk-grid-row
     .govuk-form-group.primary-subgroup-group.govuk-grid-column-one-third

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -4,7 +4,7 @@ h1.govuk-heading-xl
   | Nominations
 
 = simple_form_for @search, url: admin_form_answers_path(year: params[:year]), method: :post, as: :search, html: { class: 'search-form'} do |f|
-  .govuk-grid-row
+  .govuk-grid-row.if-no-js-hide
     = render "layouts/vertical_admin_award_year"
 
   .govuk-grid-row

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -46,5 +46,3 @@ h1.govuk-heading-xl
   = render("admin/form_answers/list_components/table", f: f)
 
   = paginate @form_answers
-
-= render("admin/form_answers/bulk_assignment_modal")

--- a/spec/controllers/admin/form_answers_controller_spec.rb
+++ b/spec/controllers/admin/form_answers_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Admin::FormAnswersController do
       it "deserializes search params" do
         search = NominationSearch.create(serialized_query: { sort: "company_or_nominee_name.asc" }.to_json)
         expect {
-          get :index, params: { search_id: search.id }
+          get :index, params: { search_id: search.id, year: "all_years" }
         }.not_to change {
           NominationSearch.count
         }
@@ -40,7 +40,7 @@ RSpec.describe Admin::FormAnswersController do
         search = NominationSearch.create(serialized_query: { sort: "company_or_nominee_name.desc" }.to_json)
 
         expect {
-          get :index, params: { search_id: search.id }
+          get :index, params: { search_id: search.id, year: "all_years" }
         }.not_to change {
           NominationSearch.count
         }


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds anchor to redirect to error message on validation failure
* Hides award year dropdown when javascript disabled.
* Updates `save_or_load_search!` method to include year params. When using the award year dropdown, the search_id is passed in the params but is not updated with the new year param. A check is therefore done to update the search record if the params[:year] does not match.
* When javascript is disabled, a new search record is created. Therefore the search param is removed from the redirect here as we instead use the year from the search record.
* Increases width of the success banner.
* Adds new copy for bulk assign assessors.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208415726190878/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

