### PR TITLE
chore: Update variable for award year in group leader citations edit page

### DIFF
--- a/app/views/group_leader/citations/edit.html.slim
+++ b/app/views/group_leader/citations/edit.html.slim
@@ -10,7 +10,7 @@
         legend.govuk-fieldset__legend.govuk-fieldset__legend--m
           h1.govuk-fieldset__heading
             | Do you accept the King's Award for Voluntary Service (KAVS)
-            =<> AwardYear.current.year
+            =<> @award_year.year
             | on behalf of your group?
         .govuk-radios.govuk-radios--inline
           .govuk-radios__item


### PR DESCRIPTION
## 📝 A short description of the changes

* Copy change to citation page to use the application award year instead of the current award year.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208512585416211/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="760" alt="Screenshot 2024-10-10 at 13 35 00" src="https://github.com/user-attachments/assets/d4a18db9-f456-4afa-bac4-735bdc678be4">
