### PR TITLE
chore: Updates media pack links on group leader dashboard

### DIFF
--- a/app/views/group_leader/dashboard/index.html.slim
+++ b/app/views/group_leader/dashboard/index.html.slim
@@ -67,13 +67,13 @@
       .govuk-details__text
         ul.govuk-list
           li
-            = link_to "The King's Award for Voluntary Service awardees' media pack 2023",
-              "https://storage.googleapis.com/emblem-files-and-guidance/Media%20pack%20for%20KAVS%20Awardees%202023.pdf",
+            = link_to "The King's Award for Voluntary Service awardees' media pack #{@award_year.year}",
+              "https://storage.googleapis.com/emblem-files-and-guidance/Media%20pack%20for%20#{@award_year.year >= 2023 ? "KAVS" : "QAVS"}%20Awardees%20#{@award_year.year}.pdf",
               rel: "noreferrer noopener",
               target: :_blank
           li
             = link_to "The King's Award for Voluntary Service media pack materials",
-              "https://storage.googleapis.com/emblem-files-and-guidance/KAVS%202023%20Media%20Pack%20Materials.pptx",
+              "https://storage.googleapis.com/emblem-files-and-guidance/#{@award_year.year >= 2023 ? "KAVS" : "QAVS"}%20#{@award_year.year}%20Media%20Pack%20Materials.pptx",
               rel: "noreferrer noopener",
               target: :_blank
           li

--- a/app/views/group_leader/dashboard/index.html.slim
+++ b/app/views/group_leader/dashboard/index.html.slim
@@ -99,7 +99,7 @@
     h3.govuk-heading-s
       | Mid December
       =<> @award_year.year
-      | - April
+      | to April
       =<> @award_year.year + 1
       | &mdash; Lord-Lieutenant presents the Award
     p.govuk-body


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds variables to media pack links to update automatically each year. Prior to 2023 the link were saved as QAVS so a conditional is added to find the correct filepath.
* Copy change to date range on group leader dashboard

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1208512585416211/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="832" alt="Screenshot 2024-10-10 at 16 01 51" src="https://github.com/user-attachments/assets/9c48610c-4d97-4dbb-bd75-f91a1dff8bf5">
