### PR TITLE
Remove 'Rails' usage before rails is loaded

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,24 +5,26 @@
 # and maximum; this matches the default thread size of Active Record.
 #
 
+# Use RAILS_ENV instead of RACK_ENV for Rails 8 compatibility
+rails_env = ENV.fetch("RAILS_ENV") { ENV.fetch("RACK_ENV") { "development" } }
+development_mode = rails_env == "development"
+
 # Reduce workers to prevent memory issues in development
-workers Integer(ENV.fetch("WEB_CONCURRENCY") { Rails.env.development? ? 0 : 2 })
+workers Integer(ENV.fetch("WEB_CONCURRENCY") { development_mode ? 0 : 2 })
 threads_count = ENV.fetch("MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
 # Only preload app in production to avoid memory issues in development
-preload_app! unless Rails.env.development?
+preload_app! unless development_mode
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
 port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
-# Use RAILS_ENV instead of RACK_ENV for Rails 8 compatibility
-environment ENV.fetch("RAILS_ENV") { ENV.fetch("RACK_ENV") { "development" } }
+environment rails_env
 
 # Only define worker boot block if running in cluster mode
-worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Rails.env.development? ? 0 : 2 })
+worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { development_mode ? 0 : 2 })
 if worker_count > 0
   on_worker_boot do
     # Worker specific setup for Rails 4.1+


### PR DESCRIPTION
## 📝 A short description of the changes

* Remove dependence on `Rails.env.development?` in `config/puma.rb` in favour of ENV variables, `RAILS_ENV` and `RACK_ENV`, as on the cloud server rails has not been loaded at this point

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits