### PR TITLE
feat: add URN to submission confirmation and mailer

### DIFF
--- a/app/mailers/users/submission_mailer.rb
+++ b/app/mailers/users/submission_mailer.rb
@@ -5,7 +5,7 @@ class Users::SubmissionMailer < ApplicationMailer
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @form_owner = @form_answer.user.decorate
     @recipient = User.find(user_id).decorate
-    @subject = "KAVS Nomination Received"
+    @subject = "KAVS Nomination Received - Application ref #{@form_answer.urn}"
 
     view_mail ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(@subject)
   end

--- a/app/views/qae_form/confirm.html.slim
+++ b/app/views/qae_form/confirm.html.slim
@@ -13,6 +13,9 @@
       .govuk-panel.govuk-panel--confirmation
         .govuk-panel__body
           strong Nomination for the King's Award for Voluntary Service was submitted.
+          br
+          p.govuk-panel__body
+            ' Your unique reference number (URN) is <strong> #{@form_answer.urn} </strong>
       br
       p.govuk-body We have sent you an email confirming your submission.
 

--- a/app/views/users/submission_mailer/success.text.erb
+++ b/app/views/users/submission_mailer/success.text.erb
@@ -3,6 +3,9 @@
 Thank you for your nomination for The King's Award for Voluntary Service (KAVS). You can access and download it via your KAVS account:
 <%= dashboard_url %>
 
+Your Unique Reference Number (URN) is
+#<%= @form_answer.urn %>. Please quote this in any future correspondence about the nomination.
+
 We will now assess the group for eligibility and will only contact you again if we require further clarification. If the group is eligible, the Lord Lieutenant in the county will contact the group leader to arrange an informal visit.  Group leaders will be notified of the eventual outcome shortly before the Award is announced next November.
 
 If you have any further queries about the nomination process you can email us kingsaward@dcms.gov.uk.

--- a/spec/mailers/users/submission_spec.rb
+++ b/spec/mailers/users/submission_spec.rb
@@ -9,7 +9,7 @@ describe Users::SubmissionMailer do
                       user: user
   end
 
-  let(:subject) { "KAVS Nomination Received" }
+  let(:subject) { "KAVS Nomination Received - Application ref #{form_answer.urn}" }
 
   before do
     form_answer


### PR DESCRIPTION
## 📝 A short description of the changes

* adds URN to mailer and confirmation page

## 🔗 Link to the relevant story (or stories)

* https://linear.app/bit-zesty/issue/KAVS-794/display-nomination-urns-in-the-admin-ui-and-allow-searching-by-urn

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="710" height="445" alt="Screenshot 2026-06-02 at 12 36 19" src="https://github.com/user-attachments/assets/8ed092ce-dfb9-4a33-90a4-44b747f4a4df" />
