### PR TITLE
fix errors on form answers page caused by deleted users

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -437,7 +437,10 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def last_updated_by
-    latest_update && latest_update.subject.full_name
+    return unless latest_update
+
+    subject = subject_including_deleted(latest_update)
+    subject && subject.full_name
   end
 
   private
@@ -452,5 +455,13 @@ class FormAnswerDecorator < ApplicationDecorator
 
   def latest_update
     object.audit_logs.data_update.order("created_at").last
+  end
+
+  def subject_including_deleted(audit_log)
+    return unless audit_log.subject_type && audit_log.subject_id
+
+    klass = audit_log.subject_type.constantize
+    scope = klass.respond_to?(:unscoped) ? klass.unscoped : klass
+    scope.find_by(id: audit_log.subject_id)
   end
 end

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -76,6 +76,39 @@ describe FormAnswerDecorator do
     end
   end
 
+  describe "#last_updated_by" do
+    let(:form_answer) { create(:form_answer) }
+    subject { described_class.new(form_answer) }
+
+    def create_update(subject_record)
+      AuditLog.create!(
+        subject: subject_record,
+        auditable: form_answer,
+        action_type: "update"
+      )
+    end
+
+    it "returns the full name of the subject who made the last update" do
+      admin = create(:admin, first_name: "Jane", last_name: "Smith")
+      create_update(admin)
+
+      expect(subject.last_updated_by).to eq("Jane Smith")
+    end
+
+    it "returns the full name even when the subject is soft-deleted" do
+      admin = create(:admin, first_name: "Jane", last_name: "Smith")
+      create_update(admin)
+      admin.soft_delete!
+
+      expect(Admin.find_by(id: admin.id)).to be_nil
+      expect(subject.last_updated_by).to eq("Jane Smith")
+    end
+
+    it "returns nil when there are no updates" do
+      expect(subject.last_updated_by).to be_nil
+    end
+  end
+
   describe "#dashboard_status" do
     it "returns fill progress when application is not submitted" do
      form_answer = create(:form_answer, state: "application_in_progress", document: { sic_code:  SicCode.first.code })


### PR DESCRIPTION
## 📝 A short description of the changes

* default scope was breaking the rendering for the full name 

## 🔗 Link to the relevant story (or stories)

* https://appsignal.com/bit-zesty/sites/60e826e214ad6641eef8e51f/exceptions/incidents/3695

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

